### PR TITLE
Adds a check for some env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,7 @@ focus-dt [options]
   --verbose, -v    Increases the log level                               [count]
   --help           Show help                                           [boolean]
 ```
+
+### Token Acquisition
+
+If not GitHub auth token is provided, then the script will look in your host environment for: `GITHUB_API_TOKEN`, `FOCUS_DT_GITHUB_API_TOKEN` and `AUTH_TOKEN` before asking for a token.

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,10 @@ async function main() {
         checkAndMerge = true;
     }
 
+    if (!token) {
+        token = process.env.GITHUB_API_TOKEN ?? process.env.FOCUS_DT_GITHUB_API_TOKEN ?? process.env.AUTH_TOKEN 
+    }
+
     if (!token && (!username || !password)) {
         ({ token, username, password } = await prompts([
             {


### PR DESCRIPTION
I think you might have the registry checks in the windows version, but I figure I can re-use some of my existing tokens for some of the other DT checks. This token is only used for reading, so any old one laying around should be fine.