### PR TITLE
Keep track of skipped items and support CLI resizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,22 +17,59 @@ focus-dt [options]
 ## Options
 
 ```
-  --version        Show version number                                 [boolean]
-  --token          GitHub Auth Token                                    [string]
-  --username       GitHub Username                                      [string]
-  --password       GitHub Password                                      [string]
-  --review         Include items from the 'Review' column of 'Pull Request
-                   Status Board'                                       [boolean]
-  --checkAndMerge  Include items from the 'Check and Merge' column of 'Pull
-                   Request Status Board'                               [boolean]
-  --oldest         Sort so that the least recently updated cards come first
+Authentication options:
+  --token                     GitHub Auth Token. Uses %GITHUB_API_TOKEN%,
+                              %FOCUS_DT_GITHUB_API_TOKEN%, or %AUTH_TOKEN% (in
+                              that order) if available                  [string]
+  --username                  GitHub Username                           [string]
+  --password                  GitHub Password                           [string]
+  --useCredentialManager, -C  Use 'git credential' to load/save the credential
+                              to use                                   [boolean]
+
+Configuration options:
+  --config   Loads settings from a JSON file
+                   [string] [default: "C:\Users\rbuckton\.focus-dt\config.json"]
+  --save     Saves settings to '%HOMEDIR%/.focus-dt/config.json' and exits
                                                                        [boolean]
-  --newest         Sort so that the most recently updated cards come first
+  --save-to  Saves settings to the specified file and exits             [string]
+
+Browser options:
+  --chromePath  The path to the chromium-based browser executable to use
+                (defaults to detecting the current system path for chrome)
+                                                                        [string]
+  --port        The remote debugging port to use to wait for the chrome tab to
+                exit                                                    [number]
+  --timeout     The number of milliseconds to wait for the debugger to attach to
+                the chrome process (default: 10,000)                    [number]
+
+Options:
+  --version      Show version number                                   [boolean]
+  --skipped      Include previously skipped items                      [boolean]
+  --needsReview  Include items from the 'Needs Maintainer Review' column of 'New
+                 Pull Request Status Board'                            [boolean]
+  --needsAction  Include items from the 'Needs Maintainer Action' column of 'New
+                 Pull Request Status Board'                            [boolean]
+  --oldest       Sort so that the least recently updated cards come first
                                                                        [boolean]
-  --port           The remote debugging port to use to wait for the chrome tab
-                   to exit.                                             [number]
-  --verbose, -v    Increases the log level                               [count]
-  --help           Show help                                           [boolean]
+  --newest       Sort so that the most recently updated cards come first
+                                                                       [boolean]
+  --draft        Include 'Draft' PRs                                   [boolean]
+  --wip          Include work-in-progress (WIP) PRs                    [boolean]
+  --merge        Set the default merge option to one of 'merge', 'squash', or
+                 'rebase'
+                      [string] [choices: "merge", "squash", "rebase", undefined]
+  --approve      Sets the approval option to one of 'manual', 'auto', 'always',
+                 or 'only' (default 'manual'):
+                 - 'manual' - Manually approve PRs in the CLI
+                 - 'auto' - Approve PRs when merging if they have no other
+                 approvers
+                 - 'always' - Approve PRs when merging if you haven't already
+                 approved
+                 - 'only' - Manually approve PRs in the CLI and advance to the
+                 next item (disables merging)
+                          [string] [choices: "manual", "auto", "always", "only"]
+  --verbose, -v  Increases the log level                                 [count]
+  --help, -h     Show help                                             [boolean]
 ```
 
 ### Token Acquisition

--- a/package.json
+++ b/package.json
@@ -7,16 +7,16 @@
   },
   "scripts": {
     "build": "tsc -p .",
-    "start": "npm run build && node dist"
+    "start": "npm run build && node bin/focus-dt"
   },
   "author": "Ron Buckton <ron.buckton@microsoft.com>",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/rbuckton/focus-dt.git"
+    "url": "https://github.com/DefinitelyTyped/focus-dt.git"
   },
   "bugs": {
-    "url": "https://github.com/rbuckton/focus-dt/issues"
+    "url": "https://github.com/DefinitelyTyped/focus-dt/issues"
   },
   "devDependencies": {
     "@types/node": "^12.0.8",

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,0 +1,28 @@
+import { WriteStream } from "fs";
+import { Chrome } from "./chrome";
+import { Column, Card, Pull, ProjectService } from "./github";
+import { Screen } from "./screen";
+
+export interface ColumnRunDownState {
+    column: Column;
+    cards: Card[];
+    offset: number;
+    oldestFirst: boolean;
+}
+
+export interface WorkArea {
+    column: ColumnRunDownState;
+    card: Card;
+}
+
+export interface Context {
+    actionState: ColumnRunDownState | undefined;
+    reviewState: ColumnRunDownState | undefined;
+    workArea: WorkArea | undefined;
+    currentPull: Pull | undefined;
+    skipped: Set<number>;
+    screen: Screen;
+    service: ProjectService;
+    chrome: Chrome;
+    log: WriteStream;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,109 +14,20 @@
    limitations under the License.
 */
 
-import * as readline from "readline";
 import * as fs from "fs";
-import * as os from "os";
 import chalk from "chalk";
 import prompts = require("prompts");
-import { argv } from "./options";
-import { ProjectService, Column, Card, Pull } from "./github";
+import { ProjectService, Column } from "./github";
 import { Chrome } from "./chrome";
-import { Prompt, pushPrompt, addOnQuit } from "./prompt";
-import { getDefaultSettings, getDefaultSettingsFile, saveSettings, Settings } from "./settings";
-
-function getRandomPort() {
-    return 9000 + Math.floor(Math.random() * 999);
-}
-
-async function init() {
-    const defaults = getDefaultSettings();
-    let {
-        token,
-        username,
-        password,
-        save,
-        "save-to": saveTo,
-        needsReview = defaults.needsReview,
-        needsAction = defaults.needsAction,
-        draft = defaults.draft,
-        oldest = defaults.oldest,
-        approve = defaults.approve,
-        merge = defaults.merge,
-        port = defaults.port,
-        timeout = defaults.timeout,
-    } = argv;
-
-    if (port <= 0) port = "random";
-
-    if (!needsReview && !needsAction) {
-        needsReview = true;
-        needsAction = true;
-    }
-
-    if (!token) {
-        token = process.env.GITHUB_API_TOKEN ?? process.env.FOCUS_DT_GITHUB_API_TOKEN ?? process.env.AUTH_TOKEN
-    }
-
-    if (!token && (!username || !password)) {
-        ({ token, username, password } = await prompts([
-            {
-                type: "select",
-                name: "choice",
-                message: "GitHub Authentication",
-                choices: [
-                    { title: "token", value: "token" },
-                    { title: "username", value: "username" },
-                ],
-            },
-            {
-                type: (_, answers) => answers.choice === "token" ? "text" : null,
-                name: "token",
-                message: "token"
-            },
-            {
-                type: (_, answers) => answers.choice === "username" ? "text" : null,
-                name: "username",
-                message: "username"
-            },
-            {
-                type: (_, answers) => answers.choice === "username" ? "text" : null,
-                name: "password",
-                message: "password"
-            },
-        ], { onCancel() { process.exit(1); } }));
-    }
-
-    const defaultMerge: "merge" | "squash" | "rebase" | undefined =
-        merge === "merge" || merge === "squash" || merge === "rebase" ? merge : undefined;
-
-    const approvalMode: "manual" | "auto" | "always" | "only" =
-        approve === "manual" || approve === "auto" || approve === "always" || approve === "only" ? approve : "manual";
-
-    const settings: Settings = {
-        needsAction,
-        needsReview,
-        oldest,
-        draft,
-        port,
-        timeout,
-        merge: defaultMerge,
-        approve: approvalMode
-    };
-
-    if (save || saveTo) {
-        saveSettings(settings, saveTo);
-        console.log(`Settings saved to '${saveTo ?? getDefaultSettingsFile()}'.`);
-        process.exit(0);
-    }
-
-    return {
-        token,
-        username,
-        password,
-        settings
-    };
-}
+import { pushPrompt, addOnQuit, isPromptVisible, hidePrompt, showPrompt, getPromptLineCount, addOnPromptSizeChange } from "./prompt";
+import { readSkipped } from "./settings";
+import { Screen } from "./screen";
+import { createMergePrompt } from "./prompts/merge";
+import { createApprovalPrompt } from "./prompts/approval";
+import { ColumnRunDownState, Context, WorkArea } from "./context";
+import { createFilterPrompt } from "./prompts/filter";
+import { createRunDownPrompt } from "./prompts/runDown";
+import { init } from "./init";
 
 async function main() {
     let {
@@ -130,375 +41,7 @@ async function main() {
         return;
     }
 
-    const runDownPrompt: Prompt = {
-        title: "Options",
-        options: [
-            {
-                key: "f",
-                description: "change filters",
-                advanced: true,
-                action: async (_, context) => {
-                    const result = await pushPrompt(filterPrompt);
-                    if (result) {
-                        context.close();
-                    }
-                },
-            },
-            {
-                key: "alt+a",
-                description: "set the default approval option",
-                advanced: true,
-                action: async (_, context) => {
-                    const result = await pushPrompt(approvalPrompt);
-                    if (result) {
-                        context.refresh();
-                    }
-                }
-            },
-            {
-                key: "alt+m",
-                description: "set the default merge option",
-                advanced: true,
-                action: async (_, context) => {
-                    const result = await pushPrompt(mergePrompt);
-                    if (result) {
-                        context.refresh();
-                    }
-                }
-            },
-            {
-                key: "ctrl+s",
-                description: "save current configuration options as defaults",
-                advanced: true,
-                action: async (_, context) => {
-                    context.hide();
-                    saveSettings(settings);
-                    process.stdout.write("Configuration saved.\n\n");
-                    context.show();
-                }
-            },
-            {
-                key: "a",
-                description: () => settings.approve === "only" ? "approve and continue" : "approve",
-                disabled: () => !!currentPull?.approvedByMe,
-                hidden: () => settings.approve !== "manual" && settings.approve !== "only",
-                action: async (_, context) => {
-                    if (!currentPull) return;
-                    context.hide();
-                    process.stdout.write("Approving...");
-                    await service.approvePull(currentPull);
-                    process.stdout.write("Approved.\n\n");
-                    log.write(`[${new Date().toISOString()}] #${currentPull.number} '${currentPull.title}': Approved\n`);
-
-                    if (settings.approve === "only") {
-                        context.close();
-                    }
-                    else {
-                        context.refresh();
-                        context.show();
-                    }
-                }
-            },
-            {
-                key: "m",
-                description: () => `${(settings.approve === "auto" ? !currentPull?.approvedByAll : settings.approve === "always" ? !currentPull?.approvedByMe : false) ? "approve and " : ""}merge${settings.merge ? ` using ${settings.merge === "merge" ? "merge commit" : settings.merge}` : ""}`,
-                disabled: () => settings.approve === "only",
-                hidden: () => settings.approve === "only",
-                action: async (_, context) => {
-                    if (!currentPull) return;
-
-                    const pull = currentPull;
-                    if (!settings.merge) {
-                        const result = await pushPrompt(mergePrompt);
-                        if (result) {
-                            context.refresh();
-                        }
-                        if (!settings.merge) return;
-                    }
-
-                    context.hide();
-
-                    const merge = settings.merge;
-                    const needsApproval =
-                        settings.approve === "auto" ? !await service.isApprovedByAll(pull) :
-                        settings.approve === "always" ? !await service.isApprovedByMe(pull) :
-                        false;
-
-                    if (needsApproval) {
-                        process.stdout.write("Approving...");
-                        await service.approvePull(pull);
-                        process.stdout.write("Approved.\n");
-                        log.write(`[${new Date().toISOString()}] #${pull.number} '${pull.title}': Approved\n`);
-                    }
-
-                    process.stdout.write("Merging...");
-                    await service.mergePull(pull, merge);
-                    log.write(`[${new Date().toISOString()}] #${pull.number} '${pull.title}': Merged using ${merge}\n`);
-                    process.stdout.write("Merged.\n\n");
-
-                    context.close();
-                }
-            },
-            {
-                key: "s",
-                description: "skip",
-                action: (_, context) => {
-                    context.close();
-                }
-            }
-        ]
-    };
-
-    interface FilterPromptState {
-        checkAndMerge: boolean;
-        review: boolean;
-        draft: boolean;
-        oldest: boolean;
-    }
-
-    const filterPrompt: Prompt<boolean, FilterPromptState> = {
-        title: "Filter Options",
-        onEnter: ({ state }) => {
-            state.checkAndMerge = settings.needsAction;
-            state.review = settings.needsReview;
-            state.draft = settings.draft;
-            state.oldest = settings.oldest;
-        },
-        options: [
-            {
-                key: "c",
-                description: ({ state }) => `${(state.checkAndMerge !== settings.needsAction ? chalk.yellow : chalk.reset)(state.checkAndMerge ? "exclude" : "include")} 'Check and Merge' column`,
-                checked: ({ state }) => state.checkAndMerge,
-                checkStyle: "checkbox",
-                action: (_, context) => {
-                    context.state.checkAndMerge = !context.state.checkAndMerge;
-                    context.refresh();
-                }
-            },
-            {
-                key: "r",
-                description: ({ state }) => `${(state.review !== settings.needsReview ? chalk.yellow : chalk.reset)(state.review ? "exclude" : "include")} 'Review' column`,
-                checkStyle: "checkbox",
-                checked: ({ state }) => state.review,
-                action: (_, context) => {
-                    context.state.review = !context.state.review;
-                    context.refresh();
-                }
-            },
-            {
-                key: "d",
-                description: ({ state }) => `${(state.draft !== settings.draft ? chalk.yellow : chalk.reset)(state.draft ? "exclude" : "include")} Draft PRs`,
-                checkStyle: "checkbox",
-                checked: ({ state }) => state.draft,
-                action: (_, context) => {
-                    context.state.draft = !context.state.draft;
-                    context.refresh();
-                }
-            },
-            {
-                key: "o",
-                description: ({ state }) => `order by ${(state.oldest !== settings.oldest ? chalk.yellow : chalk.reset)(state.oldest ? "newest" : "oldest")}`,
-                checkStyle: "checkbox",
-                checked: ({ state }) => state.oldest,
-                action: (_, context) => {
-                    context.state.oldest = !context.state.oldest;
-                    context.refresh();
-                }
-            },
-            {
-                key: "enter",
-                description: "accept changes",
-                disabled: ({ state }) =>
-                    !!state.checkAndMerge === settings.needsAction &&
-                    !!state.review === settings.needsReview &&
-                    !!state.draft === settings.draft &&
-                    !!state.oldest === settings.oldest,
-                action: (_, context) => {
-                    let shouldReset = false;
-                    const { state } = context;
-                    if (!!state.checkAndMerge !== settings.needsAction) {
-                        settings.needsAction = !!state.checkAndMerge;
-                        otherState = undefined;
-                        shouldReset = true;
-                    }
-                    if (!!state.review !== settings.needsReview) {
-                        settings.needsReview = !!state.review;
-                        reviewState = undefined;
-                        shouldReset = true;
-                    }
-                    if (!!state.draft !== settings.draft) {
-                        settings.draft = !!state.draft;
-                        otherState = undefined;
-                        reviewState = undefined;
-                        shouldReset = true;
-                    }
-                    if (!!state.oldest !== settings.oldest) {
-                        settings.oldest = !!state.oldest;
-                        otherState = undefined;
-                        reviewState = undefined;
-                        shouldReset = true;
-                    }
-                    if (shouldReset) {
-                        chrome.reset();
-                    }
-                    context.close(shouldReset);
-                }
-            },
-            {
-                key: "escape",
-                description: "cancel",
-                action: (_, context) => {
-                    context.close(false);
-                }
-            }
-        ]
-    };
-
-    interface ApprovalPromptState {
-        approvalMode: "manual" | "auto" | "always" | "only";
-    }
-
-    const approvalPrompt: Prompt<boolean, ApprovalPromptState> = {
-        title: "Approval Options",
-        onEnter: ({ state }) => {
-            state.approvalMode = settings.approve;
-        },
-        options: [
-            {
-                key: "m",
-                description: "approve PRs manually.",
-                checked: ({ state }) => state.approvalMode === "manual",
-                checkStyle: "radio",
-                checkColor: ({ state }) => ({ color: state.approvalMode !== "manual" && settings.approve === "manual" ? chalk.yellow : undefined }),
-                action: (_, context) => {
-                    context.state.approvalMode = "manual";
-                    context.refresh();
-                }
-            },
-            {
-                key: "o",
-                description: "approve PRs manually and advance (disables merge).",
-                checked: ({ state }) => state.approvalMode === "only",
-                checkStyle: "radio",
-                checkColor: ({ state }) => ({ color: state.approvalMode !== "only" && settings.approve === "only" ? chalk.yellow : undefined }),
-                action: (_, context) => {
-                    context.state.approvalMode = "only";
-                    context.refresh();
-                }
-            },
-            {
-                key: "n",
-                description: "approve PRs when merging if there are no other approvals.",
-                checked: ({ state }) => state.approvalMode === "auto",
-                checkStyle: "radio",
-                checkColor: ({ state }) => ({ color: state.approvalMode !== "auto" && settings.approve === "auto" ? chalk.yellow : undefined }),
-                action: (_, context) => {
-                    context.state.approvalMode = "auto";
-                    context.refresh();
-                }
-            },
-            {
-                key: "a",
-                description: "approve PRs when merging if you haven't already approved.",
-                checked: ({ state }) => state.approvalMode === "always",
-                checkStyle: "radio",
-                checkColor: ({ state }) => ({ color: state.approvalMode !== "always" && settings.approve === "always" ? chalk.yellow : undefined }),
-                action: (_, context) => {
-                    context.state.approvalMode = "always";
-                    context.refresh();
-                }
-            },
-            {
-                key: "enter",
-                description: "accept changes",
-                disabled: ({ state }) => state.approvalMode === settings.approve,
-                action: (_, context) => {
-                    const oldApprovalMode = settings.approve;
-                    settings.approve = context.state.approvalMode ?? settings.approve;
-                    context.close(settings.approve !== oldApprovalMode);
-                }
-            },
-            {
-                key: "escape",
-                description: "cancel",
-                action: (_, context) => context.close(false)
-            }
-        ]
-    };
-
-    interface MergePromptState {
-        defaultMerge: "merge" | "squash" | "rebase";
-    }
-
-    const mergePrompt: Prompt<boolean, MergePromptState> = {
-        title: "Merge Options",
-        onEnter: ({ state }) => {
-            state.defaultMerge = settings.merge;
-        },
-        options: [
-            {
-                key: "m",
-                description: "merge using merge commit",
-                checked: ({ state }) => state.defaultMerge === "merge",
-                checkStyle: "radio",
-                checkColor: ({ state }) => ({ color: state.defaultMerge !== "merge" && settings.merge === "merge" ? chalk.yellow : undefined }),
-                action: (_, context) => {
-                    context.state.defaultMerge = "merge";
-                    context.refresh();
-                }
-            },
-            {
-                key: "s",
-                description: "merge using squash",
-                checkStyle: "radio",
-                checked: ({ state }) => state.defaultMerge === "squash",
-                checkColor: ({ state }) => ({ color: state.defaultMerge !== "squash" && settings.merge === "squash" ? chalk.yellow : undefined }),
-                action: (_, context) => {
-                    context.state.defaultMerge = "squash";
-                    context.refresh();
-                }
-            },
-            {
-                key: "r",
-                description: "merge using rebase",
-                checkStyle: "radio",
-                checked: ({ state }) => state.defaultMerge === "rebase",
-                checkColor: ({ state }) => ({ color: state.defaultMerge !== "rebase" && settings.merge === "rebase" ? chalk.yellow : undefined }),
-                action: (_, context) => {
-                    context.state.defaultMerge = "rebase";
-                    context.refresh();
-                }
-            },
-            {
-                key: "x",
-                description: "clear default merge option",
-                checkStyle: "radio",
-                checked: ({ state }) => state.defaultMerge === undefined,
-                checkColor: ({ state }) => ({ color: state.defaultMerge !== undefined && settings.merge === undefined ? chalk.yellow : undefined }),
-                action: (_, context) => {
-                    context.state.defaultMerge = undefined;
-                    context.refresh();
-                }
-            },
-            {
-                key: "enter",
-                description: "accept changes",
-                disabled: ({ state }) => state.defaultMerge === settings.merge,
-                action: (_, context) => {
-                    const oldDefaultMerge = settings.merge;
-                    settings.merge = context.state.defaultMerge;
-                    context.close(settings.merge !== oldDefaultMerge);
-                }
-            },
-            {
-                key: "escape",
-                description: "cancel",
-                action: (_, context) => context.close(false)
-            }
-        ]
-    };
-
-    const chrome = new Chrome(settings.port === "random" ? getRandomPort() : settings.port, settings.timeout);
+    const chrome = new Chrome(settings.port, settings.timeout, settings.chromePath);
     const log = fs.createWriteStream("focus-dt.log", { flags: "a" });
 
     addOnQuit(() => {
@@ -527,185 +70,88 @@ async function main() {
 
     const project = await service.getProject();
     const columns = await service.getColumns(project);
+    const screen = new Screen(process.stdout, {
+        getPromptLineCount,
+        isPromptVisible,
+        showPrompt,
+        hidePrompt,
+        addOnPromptSizeChange
+    });
+    const context: Context = {
+        actionState: undefined,
+        reviewState: undefined,
+        currentPull: undefined,
+        workArea: undefined,
+        skipped: new Set<number>(readSkipped()),
+        screen,
+        service,
+        log,
+        chrome
+    };
 
-    class Screen {
-        private headerLines: string[] = [];
-        private logLines: string[] = [];
-        private progressLines: string[] = [];
-        private pullLines: string[] = [];
-        private writtenHeaderLines: string[] = [];
-        private writtenLogLines: string[] = [];
-        private writtenProgressLines: string[] = [];
-        private writtenPullLines: string[] = [];
+    const filterPrompt = createFilterPrompt(settings, context);
+    const approvalPrompt = createApprovalPrompt(settings);
+    const mergePrompt = createMergePrompt(settings);
+    const runDownPrompt = createRunDownPrompt(settings, context, filterPrompt, approvalPrompt, mergePrompt);
 
-        get headerStart() {
-            return 0;
-        }
-
-        get progressStart() {
-            return this.headerStart + this.writtenHeaderLines.length;
-        }
-
-        get logStart() {
-            return this.progressStart + this.writtenProgressLines.length;
-        }
-
-        get pullStart() {
-            return this.logStart + this.writtenLogLines.length;
-        }
-
-        clearHeader() {
-            this.headerLines.length = 0;
-            this.progressLines.length = 0;
-            this.logLines.length = 0;
-            this.pullLines.length = 0;
-            this.writtenProgressLines.length = 0;
-            this.writtenLogLines.length = 0;
-            this.writtenPullLines.length = 0;
-        }
-
-        clearProgress() {
-            this.logLines.length = 0;
-            this.pullLines.length = 0;
-            this.writtenLogLines.length = 0;
-            this.writtenPullLines.length = 0;
-        }
-
-        clearLog() {
-            this.logLines.length = 0;
-            this.pullLines.length = 0;
-            this.writtenPullLines.length = 0;
-        }
-
-        clearPull() {
-            this.pullLines.length = 0;
-        }
-
-        addProgress(line: string = "") {
-            this.progressLines.push(...line.split(/\r?\n/g));
-        }
-
-        addHeader(line: string = "") {
-            this.headerLines.push(...line.split(/\r?\n/g));
-        }
-
-        addLog(line: string = "") {
-            this.logLines.push(...line.split(/\r?\n/g));
-        }
-
-        addPull(line: string = "") {
-            this.pullLines.push(...line.split(/\r?\n/g));
-        }
-
-        private writeLines(y: number, source: string[], written: string[]) {
-            let i = 0;
-            while (i < source.length && i < written.length && source[i] === written[i]) {
-                i++;
-            }
-            if (written.length > i) {
-                written.length = i;
-            }
-            readline.cursorTo(process.stdout, 0, y + i);
-            readline.clearScreenDown(process.stdout);
-            while (i < source.length) {
-                const s = source[i];
-                process.stdout.write(s + "\n");
-                written.push(s);
-                i++;
-            }
-        }
-
-        writeHeader() {
-            this.writeLines(this.headerStart, this.headerLines, this.writtenHeaderLines);
-        }
-
-        writeProgress() {
-            this.writeLines(this.progressStart, this.progressLines, this.writtenProgressLines);
-        }
-
-        writeLog() {
-            this.writeLines(this.logStart, this.logLines, this.writtenLogLines);
-        }
-
-        writePull() {
-            this.writeLines(this.pullStart, this.pullLines, this.writtenPullLines);
-        }
-    }
-
-    interface ColumnRunDownState {
-        column: Column;
-        cards: Card[];
-        offset: number;
-        oldestFirst: boolean;
-    }
-
-    interface WorkArea {
-        column: ColumnRunDownState;
-        card: Card;
-    }
-
-    let otherState: ColumnRunDownState | undefined;
-    let reviewState: ColumnRunDownState | undefined;
-    let workArea: WorkArea | undefined;
-    let currentPull: Pull | undefined;
     let lastColumn: Column | undefined;
     let lastShowOther = false;
     let lastShowReview = false;
 
-    const screen = new Screen();
-
     while (true) {
-        currentPull = undefined;
-        if (settings.needsAction && shouldPopulateState(otherState)) {
-            otherState = await populateState(columns["Needs Maintainer Action"]);
+        context.currentPull = undefined;
+        if (settings.needsAction && shouldPopulateState(context.actionState)) {
+            context.actionState = await populateState(columns["Needs Maintainer Action"]);
         }
 
-        if (settings.needsReview && shouldPopulateState(reviewState)) {
-            reviewState = await populateState(columns["Needs Maintainer Review"]);
+        if (settings.needsReview && shouldPopulateState(context.reviewState)) {
+            context.reviewState = await populateState(columns["Needs Maintainer Review"]);
         }
 
         if (lastShowOther !== settings.needsAction || lastShowReview !== settings.needsReview) {
             lastShowOther = settings.needsAction;
             lastShowReview = settings.needsReview;
             screen.clearHeader();
-            screen.addHeader(`'Needs Maintainer Review' ${reviewState ? `count: ${reviewState.cards.length}` : "excluded."}`);
-            screen.addHeader(`'Needs Maintainer Action' ${otherState ? `count: ${otherState.cards.length}` : "excluded."}`);
+            screen.addHeader(`'Needs Maintainer Review' ${context.reviewState ? `count: ${context.reviewState.cards.length}` : "excluded."}`);
+            screen.addHeader(`'Needs Maintainer Action' ${context.actionState ? `count: ${context.actionState.cards.length}` : "excluded."}`);
             screen.addHeader(`order by: ${settings.oldest ? "oldest" : "newest"} first`);
             screen.addHeader();
-            screen.writeHeader();
+            screen.render();
         }
 
-        workArea = nextCard(reviewState) || nextCard(otherState);
-        if (!workArea) {
+        context.workArea = nextCard(context.reviewState) || nextCard(context.actionState);
+        if (!context.workArea) {
             lastColumn = undefined;
             screen.clearProgress();
-            screen.addProgress("No items remaining.");
-            screen.writeProgress();
+            const pluralRules = Intl.PluralRules("en-US", { type: "cardinal" });
+            const rule = pluralRules.select(context.skipped.size);
+            screen.addProgress(context.skipped.size ? `No items remaining, but there ${rule === "one" ? "is" : "are"} ${context.skipped.size} skipped ${rule === "one" ? "item" : "items"} left to review.` : "No items remaining.");
+            screen.render();
         }
         else {
-            const { column, card } = workArea;
+            const { column, card } = context.workArea;
             if (column.column !== lastColumn) {
                 lastColumn = column.column;
                 screen.clearProgress();
                 screen.addProgress(`Column '${column.column.name}':`);
                 screen.addProgress();
-                screen.writeProgress();
+                screen.render();
             }
 
-            const result = await service.getPull(card, settings.draft);
+            const result = await service.getPull(card, settings.draft, settings.wip, settings.skipped ? undefined : context.skipped);
             if (result.error) {
                 screen.addLog(`[${column.offset}/${column.cards.length}] ${result.message}, skipping.`);
-                screen.writeLog();
+                screen.render();
                 continue;
             }
 
             const { pull, labels } = result;
-            currentPull = pull;
+            context.currentPull = pull;
             screen.clearPull();
             screen.addPull(`[${column.offset}/${column.cards.length}] ${pull.title}`);
-            screen.addPull(`\t${chalk.underline(chalk.cyan(pull.html_url))}`);
+            screen.addPull(`\t${chalk.underline(chalk.cyan(pull.html_url))}${chalk.reset()}`);
             screen.addPull(`\tupdated: ${card.updated_at}`);
-            screen.addPull(`\tapproved by you: ${pull.approvedByMe ? chalk.green("yes") : "no"}, approved: ${pull.approvedByAll ? chalk.green("yes") : "no"}`);
+            screen.addPull(`\tapproved by you: ${pull.approvedByMe ? chalk.green("yes") : "no"}, approved: ${pull.approvedByAll ? chalk.green("yes") : "no"} `);
             screen.addPull(`\t${[...labels].join(', ')}`);
             if (pull.botStatus) {
                 screen.addPull();
@@ -714,8 +160,7 @@ async function main() {
                     screen.addPull(`\t${line}`);
                 }
             }
-            screen.addPull();
-            screen.writePull();
+            screen.render();
             await chrome.navigateTo(pull.html_url);
         }
 

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,0 +1,146 @@
+import prompts = require("prompts");
+import { argv } from "./options";
+import { spawn } from "child_process";
+import { getDefaultSettings, getDefaultSettingsFile, saveSettings, Settings } from "./settings";
+import { getChromePath } from "./chrome";
+
+export async function init() {
+    const defaults = getDefaultSettings();
+    let {
+        token,
+        username,
+        password,
+        save,
+        "save-to": saveTo,
+        needsReview = defaults.needsReview,
+        needsAction = defaults.needsAction,
+        draft = defaults.draft,
+        wip = defaults.wip,
+        skipped = defaults.skipped,
+        oldest = defaults.oldest,
+        approve = defaults.approve,
+        merge = defaults.merge,
+        port = defaults.port,
+        timeout = defaults.timeout,
+        chromePath,
+        useCredentialManager
+    } = argv;
+
+    if (port <= 0) port = "random";
+
+    if (!needsReview && !needsAction) {
+        needsReview = true;
+        needsAction = true;
+    }
+
+    if (!token) {
+        token = process.env.GITHUB_API_TOKEN ?? process.env.FOCUS_DT_GITHUB_API_TOKEN ?? process.env.AUTH_TOKEN
+    }
+
+    if (!token && (!username || !password)) {
+        if (useCredentialManager) {
+            const entries = new Map<string, string>();
+            await new Promise<void>((resolve) => {
+                // 'git credential fill' takes arguments via stdin using `<key>=<value>\n`, and outputs results in the same format.
+                // see https://git-scm.com/docs/git-credential#IOFMT
+                const proc = spawn("git", ["credential", "fill"], { stdio: "pipe" });
+                proc.stdout
+                    .setEncoding("utf8")
+                    .on("data", (data: string) => {
+                        const lines = data.split(/\r?\n/g);
+                        for (const line of lines) {
+                            const match = /^([^=]+)=(.*)$/.exec(line);
+                            if (!match) continue;
+                            entries.set(match[1], match[2]);
+                        }
+                    });
+                proc.stderr
+                    .setEncoding("utf8")
+                    .on("data", (data: string) => {
+                        console.log(data);
+                    });
+                proc
+                    .on("error", () => resolve())
+                    .on("close", () => resolve());
+                // write inputs
+                proc.stdin.write("protocol=https\n");
+                proc.stdin.write("host=github.com\n");
+                proc.stdin.write("path=DefinitelyTyped/DefinitelyTyped.git\n");
+                if (username) proc.stdin.write(`username=${username}\n`);
+                if (password) proc.stdin.write(`password=${password}\n`);
+                proc.stdin.write("\n");
+            });
+            username = entries.get("username");
+            password = entries.get("password");
+            if (username === "PersonalAccessToken") {
+                token = password;
+                username = undefined;
+                password = undefined;
+            }
+            if (!token && (!username || !password)) {
+                process.exit(-1);
+            }
+        }
+        else {
+            ({ token, username, password } = await prompts([
+                {
+                    type: "select",
+                    name: "choice",
+                    message: "GitHub Authentication",
+                    choices: [
+                        { title: "token", value: "token" },
+                        { title: "username", value: "username" },
+                    ],
+                },
+                {
+                    type: (_, answers) => answers.choice === "token" ? "text" : null,
+                    name: "token",
+                    message: "token"
+                },
+                {
+                    type: (_, answers) => answers.choice === "username" ? "text" : null,
+                    name: "username",
+                    message: "username"
+                },
+                {
+                    type: (_, answers) => answers.choice === "username" ? "text" : null,
+                    name: "password",
+                    message: "password"
+                },
+            ], { onCancel() { process.exit(1); } }));
+        }
+    }
+
+    const defaultMerge: "merge" | "squash" | "rebase" | undefined =
+        merge === "merge" || merge === "squash" || merge === "rebase" ? merge : undefined;
+
+    const approvalMode: "manual" | "auto" | "always" | "only" =
+        approve === "manual" || approve === "auto" || approve === "always" || approve === "only" ? approve : "manual";
+
+    const settings: Settings = {
+        needsAction,
+        needsReview,
+        oldest,
+        draft,
+        wip,
+        skipped,
+        port,
+        timeout,
+        merge: defaultMerge,
+        approve: approvalMode,
+        chromePath: chromePath ?? await getChromePath()
+    };
+
+    if (save || saveTo) {
+        saveSettings(settings, saveTo);
+        console.log(`Settings saved to '${saveTo ?? getDefaultSettingsFile()}'.`);
+        process.exit(0);
+    }
+
+    return {
+        token,
+        username,
+        password,
+        settings
+    };
+}

--- a/src/options.ts
+++ b/src/options.ts
@@ -18,39 +18,60 @@ import yargs = require("yargs");
 import { getDefaultSettingsFile, readSettings } from "./settings";
 
 export const options = yargs
+    .usage("$0 [options]")
+    // authentication
     .option("token", {
-        desc: "GitHub Auth Token. Uses %GITHUB_API_TOKEN%, %FOCUS_DT_GITHUB_API_TOKEN%, or %AUTH_TOKEN% (in that order) if available.",
+        desc: "GitHub Auth Token. Uses %GITHUB_API_TOKEN%, %FOCUS_DT_GITHUB_API_TOKEN%, or %AUTH_TOKEN% (in that order) if available",
+        group: "Authentication options:",
         conflicts: ["username", "password"],
         type: "string",
     })
     .option("username", {
         desc: "GitHub Username",
+        group: "Authentication options:",
         conflicts: ["token"],
         implies: "password",
-        type: "string"
+        type: "string",
     })
     .option("password", {
         desc: "GitHub Password",
+        group: "Authentication options:",
         conflicts: ["token"],
         implies: "username",
-        type: "string"
+        type: "string",
     })
+    .option("useCredentialManager", {
+        desc: "Use 'git credential' to load/save the credential to use",
+        group: "Authentication options:",
+        conflicts: ["token", "password"],
+        type: "boolean",
+        alias: "C",
+    })
+    // configuration
     .option("config", {
         desc: "Loads settings from a JSON file",
+        group: "Configuration options:",
         type: "string",
         config: true,
         configParser: readSettings,
         default: getDefaultSettingsFile()
     })
     .option("save", {
-        desc: "Saves settings to '%HOMEDIR%/.focus-dt/config.json' and exits.",
+        desc: "Saves settings to '%HOMEDIR%/.focus-dt/config.json' and exits",
+        group: "Configuration options:",
         type: "boolean",
         conflicts: ["save-to"]
     })
     .option("save-to", {
-        desc: "Saves settings to the specified file and exits.",
+        desc: "Saves settings to the specified file and exits",
+        group: "Configuration options:",
         type: "string",
         conflicts: ["save"]
+    })
+    // settings
+    .option("skipped", {
+        desc: "Include previously skipped items",
+        type: "boolean"
     })
     .option("needsReview", {
         desc: "Include items from the 'Needs Maintainer Review' column of 'New Pull Request Status Board'",
@@ -74,35 +95,52 @@ export const options = yargs
         desc: "Include 'Draft' PRs",
         type: "boolean",
     })
-    .option("port", {
-        desc: "The remote debugging port to use to wait for the chrome tab to exit.",
-        type: "number",
-    })
-    .option("timeout", {
-        desc: "The number of milliseconds to wait for the debugger to attach to the chrome process (default: 10,000).",
-        type: "number",
+    .option("wip", {
+        desc: "Include work-in-progress (WIP) PRs",
+        type: "boolean"
     })
     .option("merge", {
-        desc: "Set the default merge option to one of 'merge', 'squash', or 'rebase'.",
+        desc: "Set the default merge option to one of 'merge', 'squash', or 'rebase'",
         type: "string",
         choices: ["merge", "squash", "rebase", undefined],
     })
     .option("approve", {
-        desc: 
-            "Sets the approval option to one of 'manual', 'auto', 'always', or 'only' (default 'manual').\n" +
-            "  'manual' - Manually approve PRs in the CLI.\n" + 
-            "  'auto' - Approve PRs when merging if they have no other approvers.\n" +
-            "  'always' - Approve PRs when merging if you haven't already approved.\n" +
-            "  'only' - Manually approve PRs in the CLI and advance to the next item (disables merging).",
+        desc:
+            "Sets the approval option to one of 'manual', 'auto', 'always', or 'only' (default 'manual'):\n" +
+            "- 'manual' - Manually approve PRs in the CLI\n" +
+            "- 'auto' - Approve PRs when merging if they have no other approvers\n" +
+            "- 'always' - Approve PRs when merging if you haven't already approved\n" +
+            "- 'only' - Manually approve PRs in the CLI and advance to the next item (disables merging)",
         type: "string",
         choices: ["manual", "auto", "always", "only"],
     })
+    // chrome
+    .option("chromePath", {
+        desc: "The path to the chromium-based browser executable to use (defaults to detecting the current system path for chrome)",
+        group: "Browser options:",
+        type: "string"
+    })
+    .option("port", {
+        desc: "The remote debugging port to use to wait for the chrome tab to exit",
+        group: "Browser options:",
+        type: "number",
+    })
+    .option("timeout", {
+        desc: "The number of milliseconds to wait for the debugger to attach to the chrome process (default: 10,000)",
+        group: "Browser options:",
+        type: "number",
+    })
+    // other
     .option("verbose", {
         desc: "Increases the log level",
         type: "count",
         alias: ["v"]
     })
-    .help()
-    .alias(["h", "?"], "help");
+    .option("help", {
+        type: "boolean",
+        desc: "Show help",
+        alias: ["h"],
+    })
+    ;
 
 export const argv = options.argv;

--- a/src/prompts/approval.ts
+++ b/src/prompts/approval.ts
@@ -1,0 +1,77 @@
+import chalk from "chalk";
+import { Prompt } from "../prompt";
+import { Settings } from "../settings";
+
+interface ApprovalPromptState {
+    approvalMode: "manual" | "auto" | "always" | "only";
+}
+
+export function createApprovalPrompt(settings: Settings): Prompt<boolean, ApprovalPromptState> {
+    return {
+        title: "Approval Options",
+        onEnter: ({ state }) => {
+            state.approvalMode = settings.approve;
+        },
+        options: [
+            {
+                key: "m",
+                description: "approve PRs manually.",
+                checked: ({ state }) => state.approvalMode === "manual",
+                checkStyle: "radio",
+                checkColor: ({ state }) => ({ color: state.approvalMode !== "manual" && settings.approve === "manual" ? chalk.yellow : undefined }),
+                action: (_, context) => {
+                    context.state.approvalMode = "manual";
+                    context.refresh();
+                }
+            },
+            {
+                key: "o",
+                description: "approve PRs manually and advance (disables merge).",
+                checked: ({ state }) => state.approvalMode === "only",
+                checkStyle: "radio",
+                checkColor: ({ state }) => ({ color: state.approvalMode !== "only" && settings.approve === "only" ? chalk.yellow : undefined }),
+                action: (_, context) => {
+                    context.state.approvalMode = "only";
+                    context.refresh();
+                }
+            },
+            {
+                key: "n",
+                description: "approve PRs when merging if there are no other approvals.",
+                checked: ({ state }) => state.approvalMode === "auto",
+                checkStyle: "radio",
+                checkColor: ({ state }) => ({ color: state.approvalMode !== "auto" && settings.approve === "auto" ? chalk.yellow : undefined }),
+                action: (_, context) => {
+                    context.state.approvalMode = "auto";
+                    context.refresh();
+                }
+            },
+            {
+                key: "a",
+                description: "approve PRs when merging if you haven't already approved.",
+                checked: ({ state }) => state.approvalMode === "always",
+                checkStyle: "radio",
+                checkColor: ({ state }) => ({ color: state.approvalMode !== "always" && settings.approve === "always" ? chalk.yellow : undefined }),
+                action: (_, context) => {
+                    context.state.approvalMode = "always";
+                    context.refresh();
+                }
+            },
+            {
+                key: "enter",
+                description: "accept changes",
+                disabled: ({ state }) => state.approvalMode === settings.approve,
+                action: (_, context) => {
+                    const oldApprovalMode = settings.approve;
+                    settings.approve = context.state.approvalMode ?? settings.approve;
+                    context.close(settings.approve !== oldApprovalMode);
+                }
+            },
+            {
+                key: "escape",
+                description: "cancel",
+                action: (_, context) => context.close(false)
+            }
+        ]
+    };
+}

--- a/src/prompts/filter.ts
+++ b/src/prompts/filter.ts
@@ -1,0 +1,147 @@
+import chalk from "chalk";
+import { Context } from "../context";
+import { Prompt } from "../prompt";
+import { Settings } from "../settings";
+
+interface FilterPromptState {
+    checkAndMerge: boolean;
+    review: boolean;
+    draft: boolean;
+    wip: boolean;
+    skipped: boolean;
+    oldest: boolean;
+}
+
+export function createFilterPrompt(settings: Settings, appContext: Context): Prompt<boolean, FilterPromptState> {
+    return {
+        title: "Filter Options",
+        onEnter: ({ state }) => {
+            state.checkAndMerge = settings.needsAction;
+            state.review = settings.needsReview;
+            state.draft = settings.draft;
+            state.oldest = settings.oldest;
+        },
+        options: [
+            {
+                key: "c",
+                description: ({ state }) => `${(state.checkAndMerge !== settings.needsAction ? chalk.yellow : chalk.reset)(state.checkAndMerge ? "exclude" : "include")} 'Check and Merge' column`,
+                checked: ({ state }) => state.checkAndMerge,
+                checkStyle: "checkbox",
+                action: (_, context) => {
+                    context.state.checkAndMerge = !context.state.checkAndMerge;
+                    context.refresh();
+                }
+            },
+            {
+                key: "r",
+                description: ({ state }) => `${(state.review !== settings.needsReview ? chalk.yellow : chalk.reset)(state.review ? "exclude" : "include")} 'Review' column`,
+                checkStyle: "checkbox",
+                checked: ({ state }) => state.review,
+                action: (_, context) => {
+                    context.state.review = !context.state.review;
+                    context.refresh();
+                }
+            },
+            {
+                key: "d",
+                description: ({ state }) => `${(state.draft !== settings.draft ? chalk.yellow : chalk.reset)(state.draft ? "exclude" : "include")} Draft PRs`,
+                checkStyle: "checkbox",
+                checked: ({ state }) => state.draft,
+                action: (_, context) => {
+                    context.state.draft = !context.state.draft;
+                    context.refresh();
+                }
+            },
+            {
+                key: "w",
+                description: ({ state }) => `${(state.wip !== settings.wip ? chalk.yellow : chalk.reset)(state.wip ? "exclude" : "include")} Work-in-progress PRs`,
+                checkStyle: "checkbox",
+                checked: ({ state }) => state.wip,
+                action: (_, context) => {
+                    context.state.wip = !context.state.wip;
+                    context.refresh();
+                }
+            },
+            {
+                key: "s",
+                description: ({ state }) => `${(state.skipped !== settings.skipped ? chalk.yellow : chalk.reset)(state.skipped ? "exclude" : "include")} Skipped PRs`,
+                checkStyle: "checkbox",
+                checked: ({ state }) => state.skipped,
+                action: (_, context) => {
+                    context.state.skipped = !context.state.skipped;
+                    context.refresh();
+                }
+            },
+            {
+                key: "o",
+                description: ({ state }) => `order by ${(state.oldest !== settings.oldest ? chalk.yellow : chalk.reset)(state.oldest ? "newest" : "oldest")}`,
+                checkStyle: "checkbox",
+                checked: ({ state }) => state.oldest,
+                action: (_, context) => {
+                    context.state.oldest = !context.state.oldest;
+                    context.refresh();
+                }
+            },
+            {
+                key: "enter",
+                description: "accept changes",
+                disabled: ({ state }) =>
+                    !!state.checkAndMerge === settings.needsAction &&
+                    !!state.review === settings.needsReview &&
+                    !!state.draft === settings.draft &&
+                    !!state.wip === settings.wip &&
+                    !!state.skipped === settings.skipped &&
+                    !!state.oldest === settings.oldest,
+                action: (_, context) => {
+                    let shouldReset = false;
+                    const { state } = context;
+                    if (!!state.checkAndMerge !== settings.needsAction) {
+                        settings.needsAction = !!state.checkAndMerge;
+                        appContext.actionState = undefined;
+                        shouldReset = true;
+                    }
+                    if (!!state.review !== settings.needsReview) {
+                        settings.needsReview = !!state.review;
+                        appContext.reviewState = undefined;
+                        shouldReset = true;
+                    }
+                    if (!!state.draft !== settings.draft) {
+                        settings.draft = !!state.draft;
+                        appContext.actionState = undefined;
+                        appContext.reviewState = undefined;
+                        shouldReset = true;
+                    }
+                    if (!!state.wip !== settings.wip) {
+                        settings.wip = !!state.wip;
+                        appContext.actionState = undefined;
+                        appContext.reviewState = undefined;
+                        shouldReset = true;
+                    }
+                    if (!!state.skipped !== settings.skipped) {
+                        settings.skipped = !!state.skipped;
+                        appContext.actionState = undefined;
+                        appContext.reviewState = undefined;
+                        shouldReset = true;
+                    }
+                    if (!!state.oldest !== settings.oldest) {
+                        settings.oldest = !!state.oldest;
+                        appContext.actionState = undefined;
+                        appContext.reviewState = undefined;
+                        shouldReset = true;
+                    }
+                    if (shouldReset) {
+                        appContext.chrome.reset();
+                    }
+                    context.close(shouldReset);
+                }
+            },
+            {
+                key: "escape",
+                description: "cancel",
+                action: (_, context) => {
+                    context.close(false);
+                }
+            }
+        ]
+    };
+}

--- a/src/prompts/merge.ts
+++ b/src/prompts/merge.ts
@@ -1,0 +1,77 @@
+import chalk from "chalk";
+import { Prompt } from "../prompt";
+import { Settings } from "../settings";
+
+interface MergePromptState {
+    defaultMerge: "merge" | "squash" | "rebase";
+}
+
+export function createMergePrompt(settings: Settings): Prompt<boolean, MergePromptState> {
+    return {
+        title: "Merge Options",
+        onEnter: ({ state }) => {
+            state.defaultMerge = settings.merge;
+        },
+        options: [
+            {
+                key: "m",
+                description: "merge using merge commit",
+                checked: ({ state }) => state.defaultMerge === "merge",
+                checkStyle: "radio",
+                checkColor: ({ state }) => ({ color: state.defaultMerge !== "merge" && settings.merge === "merge" ? chalk.yellow : undefined }),
+                action: (_, context) => {
+                    context.state.defaultMerge = "merge";
+                    context.refresh();
+                }
+            },
+            {
+                key: "s",
+                description: "merge using squash",
+                checkStyle: "radio",
+                checked: ({ state }) => state.defaultMerge === "squash",
+                checkColor: ({ state }) => ({ color: state.defaultMerge !== "squash" && settings.merge === "squash" ? chalk.yellow : undefined }),
+                action: (_, context) => {
+                    context.state.defaultMerge = "squash";
+                    context.refresh();
+                }
+            },
+            {
+                key: "r",
+                description: "merge using rebase",
+                checkStyle: "radio",
+                checked: ({ state }) => state.defaultMerge === "rebase",
+                checkColor: ({ state }) => ({ color: state.defaultMerge !== "rebase" && settings.merge === "rebase" ? chalk.yellow : undefined }),
+                action: (_, context) => {
+                    context.state.defaultMerge = "rebase";
+                    context.refresh();
+                }
+            },
+            {
+                key: "x",
+                description: "clear default merge option",
+                checkStyle: "radio",
+                checked: ({ state }) => state.defaultMerge === undefined,
+                checkColor: ({ state }) => ({ color: state.defaultMerge !== undefined && settings.merge === undefined ? chalk.yellow : undefined }),
+                action: (_, context) => {
+                    context.state.defaultMerge = undefined;
+                    context.refresh();
+                }
+            },
+            {
+                key: "enter",
+                description: "accept changes",
+                disabled: ({ state }) => state.defaultMerge === settings.merge,
+                action: (_, context) => {
+                    const oldDefaultMerge = settings.merge;
+                    settings.merge = context.state.defaultMerge;
+                    context.close(settings.merge !== oldDefaultMerge);
+                }
+            },
+            {
+                key: "escape",
+                description: "cancel",
+                action: (_, context) => context.close(false)
+            }
+        ]
+    };
+}

--- a/src/prompts/runDown.ts
+++ b/src/prompts/runDown.ts
@@ -1,0 +1,145 @@
+import chalk from "chalk";
+import { Context } from "../context";
+import { Prompt, pushPrompt } from "../prompt";
+import { saveSettings, saveSkipped, Settings } from "../settings";
+import { tryAdd } from "../utils";
+
+export function createRunDownPrompt(settings: Settings, appContext: Context, filterPrompt: Prompt<boolean>, approvalPrompt: Prompt<boolean>, mergePrompt: Prompt<boolean>): Prompt {
+    return {
+        title: "Options",
+        options: [
+            {
+                key: "f",
+                description: "change filters",
+                advanced: true,
+                action: async (_, context) => {
+                    const result = await pushPrompt(filterPrompt);
+                    if (result) {
+                        context.close();
+                    }
+                },
+            },
+            {
+                key: "alt+a",
+                description: "set the default approval option",
+                advanced: true,
+                action: async (_, context) => {
+                    const result = await pushPrompt(approvalPrompt);
+                    if (result) {
+                        context.refresh();
+                    }
+                }
+            },
+            {
+                key: "alt+m",
+                description: "set the default merge option",
+                advanced: true,
+                action: async (_, context) => {
+                    const result = await pushPrompt(mergePrompt);
+                    if (result) {
+                        context.refresh();
+                    }
+                }
+            },
+            {
+                key: "ctrl+s",
+                description: "save current configuration options as defaults",
+                advanced: true,
+                action: async (_, context) => {
+                    context.hide();
+                    saveSettings(settings);
+                    process.stdout.write("Configuration saved.\n\n");
+                    context.show();
+                }
+            },
+            {
+                key: "a",
+                description: () => settings.approve === "only" ? "approve and continue" : "approve",
+                disabled: () => !!appContext.currentPull?.approvedByMe,
+                hidden: () => settings.approve !== "manual" && settings.approve !== "only",
+                action: async (_, context) => {
+                    if (!appContext.currentPull) return;
+                    context.hide();
+                    process.stdout.write("Approving...");
+                    await appContext.service.approvePull(appContext.currentPull);
+                    process.stdout.write("Approved.\n\n");
+                    appContext.log.write(`[${new Date().toISOString()}] #${appContext.currentPull.number} '${appContext.currentPull.title}': Approved\n`);
+
+                    if (settings.approve === "only") {
+                        if (appContext.skipped.delete(appContext.currentPull.number)) {
+                            saveSkipped(appContext.skipped);
+                        }
+                        context.close();
+                    }
+                    else {
+                        context.refresh();
+                        context.show();
+                    }
+                }
+            },
+            {
+                key: "m",
+                description: () => `${(settings.approve === "auto" ? !appContext.currentPull?.approvedByAll : settings.approve === "always" ? !appContext.currentPull?.approvedByMe : false) ? "approve and " : ""}merge${settings.merge ? ` using ${settings.merge === "merge" ? "merge commit" : settings.merge}` : ""}`,
+                disabled: () => settings.approve === "only",
+                hidden: () => settings.approve === "only",
+                action: async (_, context) => {
+                    if (!appContext.currentPull) return;
+
+                    const pull = appContext.currentPull;
+                    if (!settings.merge) {
+                        const result = await pushPrompt(mergePrompt);
+                        if (result) {
+                            context.refresh();
+                        }
+                        if (!settings.merge) return;
+                    }
+
+                    context.hide();
+
+                    const merge = settings.merge;
+                    const needsApproval =
+                        settings.approve === "auto" ? !await appContext.service.isApprovedByAll(pull) :
+                        settings.approve === "always" ? !await appContext.service.isApprovedByMe(pull) :
+                        false;
+
+                    if (needsApproval) {
+                        process.stdout.write("Approving...");
+                        await appContext.service.approvePull(pull);
+                        process.stdout.write("Approved.\n");
+                        appContext.log.write(`[${new Date().toISOString()}] #${pull.number} '${pull.title}': Approved\n`);
+                    }
+
+                    process.stdout.write("Merging...");
+                    await appContext.service.mergePull(pull, merge);
+                    appContext.log.write(`[${new Date().toISOString()}] #${pull.number} '${pull.title}': Merged using ${merge}\n`);
+                    process.stdout.write("Merged.\n\n");
+
+                    if (appContext.skipped.delete(appContext.currentPull.number)) {
+                        saveSkipped(appContext.skipped);
+                    }
+
+                    context.close();
+                }
+            },
+            {
+                key: "s",
+                description: "skip",
+                action: (_, context) => {
+                    if (appContext.currentPull && tryAdd(appContext.skipped, appContext.currentPull.number)) {
+                        appContext.screen.addLog(`[${appContext.workArea?.column.offset}/${appContext.workArea?.column.cards.length}] ${appContext.currentPull.title} ${chalk.yellow("[skipped]")}.`)
+                        saveSkipped(appContext.skipped);
+                    }
+                    context.close();
+                }
+            },
+            {
+                key: "F5",
+                description: "Refresh",
+                hidden: true,
+                action: () => {
+                    appContext.screen.refresh(true);
+                }
+            }
+        ]
+    };
+}

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -16,6 +16,8 @@
 
 import Registry = require("winreg");
 
+export const HKLM = Registry.HKLM;
+
 export function regQuery(hive: string, key: string, valueName: string = Registry.DEFAULT_VALUE) {
     return new Promise<string | undefined>((resolve, reject) => {
         const reg = new Registry({ hive, key });

--- a/src/screen.ts
+++ b/src/screen.ts
@@ -1,0 +1,228 @@
+import * as readline from "readline";
+import chalk, { Chalk } from "chalk";
+import { wordWrap } from "./wordWrap";
+
+const ESC = "\x1B";
+const CSI = `${ESC}[`;
+const emptyArray: readonly never[] = [];
+
+interface ScreenSection {
+    y: number;
+    lines: string[];
+}
+
+interface PromptInfo {
+    getPromptLineCount(): number;
+    isPromptVisible(): boolean;
+    showPrompt(raiseEvents?: boolean): Promise<boolean>;
+    hidePrompt(raiseEvents?: boolean): Promise<boolean>;
+    addOnPromptSizeChange(cb: () => void | Promise<void>): void;
+}
+
+export class Screen {
+    private headerLines: string[] = [];
+    private logLines: string[] = [];
+    private progressLines: string[] = [];
+    private pullLines: string[] = [];
+    private writtenHeaderLines: ScreenSection = { y: 0, lines: [] };
+    private writtenLogLines: ScreenSection = { y: 0, lines: [] };
+    private writtenProgressLines: ScreenSection = { y: 0, lines: [] };
+    private writtenPullLines: ScreenSection = { y: 0, lines: [] };
+    private width = 120;
+    private height = Infinity;
+    private prompt: PromptInfo;
+    private output: NodeJS.WriteStream;
+
+    constructor(output: NodeJS.WriteStream, prompt: PromptInfo) {
+        this.prompt = prompt;
+        this.output = output;
+        this.width = this.output.columns ?? Infinity;
+        this.height = this.output.rows ?? Infinity;
+        this.output.on("resize", () => process.nextTick(() => this.refresh()));
+        this.prompt.addOnPromptSizeChange(() => {
+            this.refresh(true);
+        });
+    }
+
+    get headerStart() {
+        return 0;
+    }
+
+    get progressStart() {
+        return this.headerStart + this.writtenHeaderLines.lines.length;
+    }
+
+    get logStart() {
+        return this.progressStart + this.writtenProgressLines.lines.length;
+    }
+
+    get pullStart() {
+        return this.logStart + this.writtenLogLines.lines.length;
+    }
+
+    clearHeader() {
+        this.headerLines.length = 0;
+        this.resetSection(this.writtenProgressLines);
+        this.clearProgress();
+    }
+
+    clearProgress() {
+        this.progressLines.length = 0;
+        this.resetSection(this.writtenLogLines);
+        this.clearLog();
+    }
+
+    clearLog() {
+        this.logLines.length = 0;
+        this.resetSection(this.writtenPullLines);
+        this.clearPull();
+    }
+
+    clearPull() {
+        this.pullLines.length = 0;
+    }
+
+    addProgress(line: string = "") {
+        this.progressLines.push(...line.split(/\r?\n/g));
+    }
+
+    addHeader(line: string = "") {
+        this.headerLines.push(...line.split(/\r?\n/g));
+    }
+
+    addLog(line: string = "") {
+        const lines = line.split(/\r?\n/g);
+        this.logLines.push(...lines);
+    }
+
+    addPull(line: string = "") {
+        this.pullLines.push(...line.split(/\r?\n/g));
+    }
+
+    private resetSection(section: ScreenSection) {
+        section.y = 0;
+        section.lines.length = 0;
+    }
+
+    private reflowSource(source: readonly string[]) {
+        if (source.some(line => line.length > this.width)) {
+            let reflow: string[] = [];
+            for (const line of source) {
+                if (line.length > this.width) {
+                    reflow.push(line);
+                }
+                else {
+                    reflow = reflow.concat(wordWrap(line, this.width));
+                }
+            }
+            source = reflow;
+        }
+        return source;
+    }
+
+    private writeLines(y: number, source: readonly string[], written: ScreenSection) {
+        let i = 0;
+        if (y !== written.y) {
+            written.y = y;
+            written.lines.length = 0;
+        }
+        else {
+            while (i < source.length && i < written.lines.length && source[i] === written.lines[i]) {
+                i++;
+            }
+            if (written.lines.length > i) {
+                written.lines.length = i;
+            }
+        }
+        this.cursorTo(0, y + i);
+        while (i < source.length) {
+            const s = source[i];
+            this.clearLine();
+            this.output.write(s + "\n");
+            written.lines.push(s);
+            i++;
+        }
+        return i;
+    }
+
+    render() {
+        try {
+            this.hideCursor();
+            const writePull = this.pullLines.length > 0;
+            const writeLog = writePull || this.logLines.length > 0;
+            const writeProgress = writeLog || this.progressLines.length > 0;
+            const writeHeader = writeProgress || this.headerLines.length > 0;
+            const header = writeHeader ? this.reflowSource(this.headerLines) : emptyArray;
+            const progress = writeProgress ? this.reflowSource(this.progressLines) : emptyArray;
+            const pull = writePull ? this.reflowSource(this.pullLines) : emptyArray;
+            let log = writeLog ? this.reflowSource(this.logLines) : emptyArray;
+            let y = 0;
+            if (writeHeader) {
+                y += this.writeLines(y, header, this.writtenHeaderLines);
+                if (writeProgress) {
+                    y += this.writeLines(y, progress, this.writtenProgressLines);
+                    if (writeLog) {
+                        const limit = this.height - header.length - progress.length - pull.length - this.prompt.getPromptLineCount() - 1;
+                        log = log.slice(-limit);
+                        log = log.map(line => chalk.gray(line));
+                        y += this.writeLines(y, log, this.writtenLogLines);
+                        if (writePull) {
+                            this.writeLines(y, pull, this.writtenPullLines);
+                        }
+                    }
+                }
+                this.clearScreenDown();
+            }
+        } 
+        finally {
+            this.showCursor();
+        }
+    }
+
+    async refresh(force?: boolean) {
+        const prompting = this.prompt.isPromptVisible();
+        if (prompting) await this.prompt.hidePrompt(false);
+        this.width = this.output.columns ?? Infinity;
+        this.height = this.output.rows ?? Infinity;
+        if (force) {
+            this.writtenHeaderLines.y = 0;
+            this.writtenHeaderLines.lines.length = 0;
+            this.writtenProgressLines.y = 0;
+            this.writtenProgressLines.lines.length = 0;
+            this.writtenLogLines.y = 0;
+            this.writtenLogLines.lines.length = 0;
+            this.writtenPullLines.y = 0;
+            this.writtenPullLines.lines.length = 0;
+            this.cursorTo(0, 0);
+            this.eraseDisplay();
+            this.clearScreenDown();
+            this.cursorTo(0, 0);
+        }
+        this.render();
+        if (prompting) await this.prompt.showPrompt(false);
+    }
+
+    private hideCursor() {
+        this.output.write(`${CSI}?25l`);
+    }
+
+    private showCursor() {
+        this.output.write(`${CSI}?25h`);
+    }
+
+    private cursorTo(x: number, y?: number) {
+        readline.cursorTo(this.output, x, y);
+    }
+
+    private clearLine(dir: -1 | 0 | 1 = 0) {
+        readline.clearLine(this.output, dir);
+    }
+
+    private clearScreenDown() {
+        readline.clearScreenDown(this.output);
+    }
+
+    private eraseDisplay() {
+        this.output.write(`${CSI}3J`);
+    }
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -7,10 +7,13 @@ export interface Settings {
     needsAction: boolean;
     oldest: boolean;
     draft: boolean;
+    wip: boolean;
+    skipped: boolean;
     port: number | "random";
     timeout: number;
     merge: "merge" | "squash" | "rebase" | undefined;
     approve: "manual" | "auto" | "always" | "only";
+    chromePath: string | undefined;
 }
 
 export function getDefaultSettingsFile() {
@@ -27,10 +30,13 @@ export function saveSettings(settings: Settings, file = getDefaultSettingsFile()
         json.needsReview = undefined;
     }
     if (json.draft === false) json.draft = undefined;
+    if (json.wip === false) json.wip = undefined;
+    if (json.skipped === false) json.skipped = undefined;
     if (json.oldest === false) json.oldest = undefined;
     if (json.approve === "manual") json.approve = undefined;
     if (json.port === 9222) json.port = undefined;
     if (json.timeout === 10000) json.timeout = undefined;
+    if (json.chromePath === "") json.chromePath = undefined;
     const settingsDir = path.dirname(file);
     try { fs.mkdirSync(settingsDir, { recursive: true }); } catch { }
     fs.writeFileSync(file, JSON.stringify(json, undefined, "  "), "utf8");
@@ -51,10 +57,48 @@ export function getDefaultSettings(): Settings {
         needsReview: false,
         needsAction: false,
         draft: false,
+        wip: false,
+        skipped: false,
         oldest: false,
         approve: "manual",
         merge: undefined,
         port: 9222,
-        timeout: 10000
+        timeout: 10000,
+        chromePath: undefined
     };
+}
+
+export function getDefaultSkippedFile() {
+    const homedir = os.homedir();
+    const settingsDir = path.join(homedir, ".focus-dt");
+    return path.join(settingsDir, "skipped.json");
+}
+
+export function saveSkipped(skipped: Set<number> | number[] | undefined, file = getDefaultSkippedFile()) {
+    if (path.extname(file) !== ".json") throw new Error(`Skipped PR file must have a .json extension: '${file}'`);
+    if (skipped && !Array.isArray(skipped)) skipped = [...skipped];
+    if (!skipped?.length) {
+        try {
+            fs.unlinkSync(file);
+        }
+        catch {
+            // do nothing
+        }
+    }
+    else {
+        const settingsDir = path.dirname(file);
+        try { fs.mkdirSync(settingsDir, { recursive: true }); } catch { }
+        fs.writeFileSync(file, JSON.stringify(skipped, undefined, "  "), "utf8");
+    }
+}
+
+export function readSkipped(file = getDefaultSkippedFile()) {
+    try {
+        const text = fs.readFileSync(file, "utf8");
+        const array = JSON.parse(text) as number[];
+        if (Array.isArray(array) && array.every(x => typeof x === "number")) return array;
+    }
+    catch {
+        // do nothing
+    }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,5 @@
+export function tryAdd<T>(set: Set<T>, value: T) {
+    const size = set.size;
+    set.add(value);
+    return set.size > size;
+}

--- a/src/wordWrap.ts
+++ b/src/wordWrap.ts
@@ -1,0 +1,69 @@
+interface Token {
+    kind: "escape" | "word" | "word-break" | "line-break";
+    value: string;
+}
+
+const tokenizerRegExp = /(?<escape>(?:\u001b\[\d*(?:;\d*)+m)+)|(?<lineBreak>\r?\n)|(?<wordBreak>[\s\u200b]+)|(?<character>.)/yu;
+
+function * tokenize(s: string): IterableIterator<Token> {
+    let pos = 0;
+    let wordStart = 0;
+    while (pos < s.length) {
+        tokenizerRegExp.lastIndex = pos;
+        const match = tokenizerRegExp.exec(s);
+        if (!match?.groups) throw new Error();
+        const { escape, lineBreak, wordBreak, character } = match.groups;
+        const nextPos = match.index + match[0].length;
+        if (!character) {
+            if (wordStart < pos) {
+                yield { kind: "word", value: s.slice(wordStart, pos) };
+            }
+            if (escape) {
+                yield { kind: "escape", value: escape };
+            }
+            else if (lineBreak) {
+                yield { kind: "line-break", value: lineBreak };
+            }
+            else if (wordBreak) {
+                yield { kind: "word-break", value: wordBreak };
+            }
+            wordStart = nextPos;
+        }
+        pos = nextPos;
+    }
+    if (wordStart < s.length) {
+        yield { kind: "word", value: s.slice(wordStart) };
+    }
+}
+
+export function wordWrap(s: string, width: number) {
+    const lines: string[] = [];
+    let lineSize = 0;
+    let line = "";
+    for (const token of tokenize(s)) {
+        if (token.kind === "line-break") {
+            lines.push(line);
+            line = "";
+            lineSize = 0;
+            continue;
+        }
+        if (token.kind === "escape") {
+            line += token.value;
+            continue;
+        }
+        if (lineSize + token.value.length > width) {
+            lines.push(line.replace(/\s+$/, ""));
+            line = "";
+            lineSize = 0;
+            if (token.kind === "word-break" && token.value === " ") {
+                continue;
+            }
+        }
+        line += token.value;
+        lineSize += token.value.length;
+    }
+    if (line) {
+        lines.push(line);
+    }
+    return lines;
+}


### PR DESCRIPTION
This PR cleans up and reorganizes some of the sources, and adds the following features:

- Support authentication using `git credential` (and saved credentials using `git-credential-manager`)
- Save skipped items between restarts
- Toggle whether to show skipped items
- Toggle whether to skip items with `WIP` in the title (indicating a work-in-progress)
- Support customization of the location of the chromium executable to launch
- Reflow parts of the CLI when the terminal is resized
- `F5` command to refresh the CLI

