### PR TITLE
Always use 'git credential' when not provided a token

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,1191 @@
 {
   "name": "focus-dt",
   "version": "1.0.4",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "version": "1.0.4",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@octokit/rest": "^18.5.2",
+        "equatable": "^1.2.0",
+        "iterable-query": "^1.0.0-pre.15",
+        "vscode-chrome-debug-core": "^6.7.50",
+        "winreg": "^1.2.4",
+        "yargs": "^13.2.4"
+      },
+      "bin": {
+        "focus-dt": "bin/focus-dt"
+      },
+      "devDependencies": {
+        "@types/color-convert": "^2.0.0",
+        "@types/node": "^12.0.8",
+        "@types/winreg": "^1.2.30",
+        "@types/yargs": "^13.0.0",
+        "chalk": "^3.0.0",
+        "typescript": "^4.1.2"
+      }
+    },
+    "node_modules/@esfx/collection-core": {
+      "version": "1.0.0-pre.8",
+      "resolved": "https://registry.npmjs.org/@esfx/collection-core/-/collection-core-1.0.0-pre.8.tgz",
+      "integrity": "sha512-yL0GxAcwKM+Gn8zamSGpXO2zbVoX3BRQ1PC/KqyY8Y7rNUv9ObXVrSA8imjXYD0JVx4K7btSVJLiFo/25AVU5w==",
+      "dependencies": {
+        "@esfx/internal-guards": "^1.0.0-pre.6",
+        "tslib": "^1.9.3"
+      }
+    },
+    "node_modules/@esfx/collection-core-shim": {
+      "version": "1.0.0-pre.8",
+      "resolved": "https://registry.npmjs.org/@esfx/collection-core-shim/-/collection-core-shim-1.0.0-pre.8.tgz",
+      "integrity": "sha512-OKseMmQTWRi2i+J5Cezru9Y1qniKWwbc648zQez2QIXFbPrT/v7qmbyQhZBw1SJkOv230cXbY3062wT8BDJW7g==",
+      "dependencies": {
+        "@esfx/collection-core": "^1.0.0-pre.8",
+        "tslib": "^1.9.3"
+      }
+    },
+    "node_modules/@esfx/collections": {
+      "version": "1.0.0-pre.8",
+      "resolved": "https://registry.npmjs.org/@esfx/collections/-/collections-1.0.0-pre.8.tgz",
+      "integrity": "sha512-phqqbeGicM0hD/BQPO2g11aT0nDnrkXCKZvoHfcdeiMI4zJQW7s+u51CUDwTOj5tCK2LFRQGol66Qx4acGUW/w==",
+      "dependencies": {
+        "@esfx/collections-hashmap": "^1.0.0-pre.8",
+        "@esfx/collections-hashset": "^1.0.0-pre.8",
+        "@esfx/collections-linkedlist": "^1.0.0-pre.8",
+        "@esfx/collections-sortedmap": "^1.0.0-pre.8",
+        "@esfx/collections-sortedset": "^1.0.0-pre.8",
+        "tslib": "^1.9.3"
+      }
+    },
+    "node_modules/@esfx/collections-hashmap": {
+      "version": "1.0.0-pre.8",
+      "resolved": "https://registry.npmjs.org/@esfx/collections-hashmap/-/collections-hashmap-1.0.0-pre.8.tgz",
+      "integrity": "sha512-Tfd//Q0r41w4N9/w/lDbNHzsqUdZmjy7un3gfJY9XlvQJ+FCsMUsTv3zAoosyosIn8qDVnVQwh7yoLjkCYe/fw==",
+      "dependencies": {
+        "@esfx/collection-core": "^1.0.0-pre.8",
+        "@esfx/equatable": "^1.0.0-pre.8",
+        "@esfx/internal-collections-hash": "^1.0.0-pre.8",
+        "@esfx/internal-guards": "^1.0.0-pre.6",
+        "tslib": "^1.9.3"
+      }
+    },
+    "node_modules/@esfx/collections-hashset": {
+      "version": "1.0.0-pre.8",
+      "resolved": "https://registry.npmjs.org/@esfx/collections-hashset/-/collections-hashset-1.0.0-pre.8.tgz",
+      "integrity": "sha512-U8c/tRBZmx44KrgJcLqr13QaCMWpqt5wD3ittCVeGy7hDp0OZuVNhAsUpIW2MfQlSUjNwlOxlwcEOmjuOLOBug==",
+      "dependencies": {
+        "@esfx/collection-core": "^1.0.0-pre.8",
+        "@esfx/equatable": "^1.0.0-pre.8",
+        "@esfx/internal-collections-hash": "^1.0.0-pre.8",
+        "@esfx/internal-guards": "^1.0.0-pre.6",
+        "tslib": "^1.9.3"
+      }
+    },
+    "node_modules/@esfx/collections-linkedlist": {
+      "version": "1.0.0-pre.8",
+      "resolved": "https://registry.npmjs.org/@esfx/collections-linkedlist/-/collections-linkedlist-1.0.0-pre.8.tgz",
+      "integrity": "sha512-a9nkDzo1qP4qlXuZszpYo50fKBVOckovu5IPGiGSagJhIBUf379w9jTBnYI3CaJB1FihzI9RgOu02i2MtKR9Wg==",
+      "dependencies": {
+        "@esfx/collection-core": "^1.0.0-pre.8",
+        "@esfx/equatable": "^1.0.0-pre.8",
+        "@esfx/internal-guards": "^1.0.0-pre.6",
+        "tslib": "^1.9.3"
+      }
+    },
+    "node_modules/@esfx/collections-sortedmap": {
+      "version": "1.0.0-pre.8",
+      "resolved": "https://registry.npmjs.org/@esfx/collections-sortedmap/-/collections-sortedmap-1.0.0-pre.8.tgz",
+      "integrity": "sha512-+hLpey41F8wqxNlevfe0FWtQuPxpr6YRBAiSjZJ7DhAuCN0UTGacdrIwxrZ1Y09f4JBui4NkDD0/aoECH3n3oA==",
+      "dependencies": {
+        "@esfx/collection-core": "^1.0.0-pre.8",
+        "@esfx/equatable": "^1.0.0-pre.8",
+        "@esfx/internal-binarysearch": "^1.0.0-pre.8",
+        "@esfx/internal-guards": "^1.0.0-pre.6",
+        "tslib": "^1.9.3"
+      }
+    },
+    "node_modules/@esfx/collections-sortedset": {
+      "version": "1.0.0-pre.8",
+      "resolved": "https://registry.npmjs.org/@esfx/collections-sortedset/-/collections-sortedset-1.0.0-pre.8.tgz",
+      "integrity": "sha512-1rN8lT9++1ief2Db6jvTq2ya2cnMPP7OgN6suwBmTLKy5hbHIDdtfwGTLiyomn1Xd7eaVzAvCpEX7j+wiJTNhA==",
+      "dependencies": {
+        "@esfx/collection-core": "^1.0.0-pre.8",
+        "@esfx/equatable": "^1.0.0-pre.8",
+        "@esfx/internal-binarysearch": "^1.0.0-pre.8",
+        "@esfx/internal-guards": "^1.0.0-pre.6",
+        "tslib": "^1.9.3"
+      }
+    },
+    "node_modules/@esfx/equatable": {
+      "version": "1.0.0-pre.8",
+      "resolved": "https://registry.npmjs.org/@esfx/equatable/-/equatable-1.0.0-pre.8.tgz",
+      "integrity": "sha512-HdEGOVjg3ebPxeM3n1E02TxCkHqCdKocwKtd+ilc6SDfDt2D+NdVfFvnb/E3s1a2bcSYyAF0/KZ4zYRimNGmRw==",
+      "dependencies": {
+        "@esfx/internal-hashcode": "^1.0.0-pre.5",
+        "tslib": "^1.9.3"
+      }
+    },
+    "node_modules/@esfx/equatable-shim": {
+      "version": "1.0.0-pre.8",
+      "resolved": "https://registry.npmjs.org/@esfx/equatable-shim/-/equatable-shim-1.0.0-pre.8.tgz",
+      "integrity": "sha512-a3EJW1se7JvEXJIC9cl9HSmkNLkA1nRMXwhd2s9gkDF8M5A4+clEwRV+tkYH8aSmx4ipfTzoWARjVsnB2sLrqA==",
+      "dependencies": {
+        "@esfx/equatable": "^1.0.0-pre.8",
+        "@esfx/internal-hashcode": "^1.0.0-pre.5",
+        "tslib": "^1.9.3"
+      }
+    },
+    "node_modules/@esfx/internal-binarysearch": {
+      "version": "1.0.0-pre.8",
+      "resolved": "https://registry.npmjs.org/@esfx/internal-binarysearch/-/internal-binarysearch-1.0.0-pre.8.tgz",
+      "integrity": "sha512-+9UZjdauYHOO91UhplYoP3BsuY7IBag6RsZWxgIg1C2UmroZrnYW4ctg9MaxR/vAJXGuPRJEZWhKfS82Pw/4Qg==",
+      "dependencies": {
+        "@esfx/equatable": "^1.0.0-pre.8",
+        "tslib": "^1.9.3"
+      }
+    },
+    "node_modules/@esfx/internal-collections-hash": {
+      "version": "1.0.0-pre.8",
+      "resolved": "https://registry.npmjs.org/@esfx/internal-collections-hash/-/internal-collections-hash-1.0.0-pre.8.tgz",
+      "integrity": "sha512-HITxwzxOrtSHM5VpQB1HrRrK3zjJX4EXAVfos2UCjN/czaUjmzmbuarYS7YJJdIsDnJo1LGMhSjw3XzY1PvqGA==",
+      "dependencies": {
+        "@esfx/equatable": "^1.0.0-pre.8",
+        "@esfx/internal-integers": "^1.0.0-pre.5",
+        "tslib": "^1.9.3"
+      }
+    },
+    "node_modules/@esfx/internal-guards": {
+      "version": "1.0.0-pre.6",
+      "resolved": "https://registry.npmjs.org/@esfx/internal-guards/-/internal-guards-1.0.0-pre.6.tgz",
+      "integrity": "sha512-BHUioO3f/zURjNmTIgtVSnD9RNm+TUf7BYfvkF58xJtoO/ARkAU3n8ylwCT7g0ikoT2EheUAfU+6MVWXuWPwEw==",
+      "dependencies": {
+        "@esfx/type-model": "^1.0.0-pre.6",
+        "tslib": "^1.9.3"
+      }
+    },
+    "node_modules/@esfx/internal-hashcode": {
+      "version": "1.0.0-pre.5",
+      "resolved": "https://registry.npmjs.org/@esfx/internal-hashcode/-/internal-hashcode-1.0.0-pre.5.tgz",
+      "integrity": "sha512-1QZcTEGTP0Qdg3VTxAjjNviHSX7JaPN/ZoBHZQrXcVMXFvMo5vuFsisVjdxjWFFjOgoNwXzqA8lSrkMhrHgpdA==",
+      "dependencies": {
+        "@esfx/internal-murmur3": "^1.0.0-pre.5",
+        "tslib": "^1.9.3"
+      }
+    },
+    "node_modules/@esfx/internal-integers": {
+      "version": "1.0.0-pre.5",
+      "resolved": "https://registry.npmjs.org/@esfx/internal-integers/-/internal-integers-1.0.0-pre.5.tgz",
+      "integrity": "sha512-+HrVfzHbWhKZ0AqteSeL9SCTToK3+Xi9S7dkO1FHDqfVZqJLrVTNklfOJVAoiHA9c9se3DrGTcxZxzNOYcuazw==",
+      "dependencies": {
+        "tslib": "^1.9.3"
+      }
+    },
+    "node_modules/@esfx/internal-murmur3": {
+      "version": "1.0.0-pre.5",
+      "resolved": "https://registry.npmjs.org/@esfx/internal-murmur3/-/internal-murmur3-1.0.0-pre.5.tgz",
+      "integrity": "sha512-Jq+oO1sbxWeUvIoyS7tOF+jg1KLitOOD1/TPTmdYGu/ss53kM8GXaGw5H4x/g07tQfQdC3QyDlepxK/dvoQqoQ==",
+      "dependencies": {
+        "tslib": "^1.9.3"
+      }
+    },
+    "node_modules/@esfx/type-model": {
+      "version": "1.0.0-pre.6",
+      "resolved": "https://registry.npmjs.org/@esfx/type-model/-/type-model-1.0.0-pre.6.tgz",
+      "integrity": "sha512-P6XiQ8fRixLJN9nmMw8/EXgrRubSYbF6o/9dIRdC9KTOzzRDMgwPCnun1uZ06Ulmetn8unvwUExIE9YsRntLeQ==",
+      "dependencies": {
+        "tslib": "^1.9.3"
+      }
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.4.tgz",
+      "integrity": "sha512-LNfGu3Ro9uFAYh10MUZVaT7X2CnNm2C8IDQmabx+3DygYIQjs9FwzFAHN/0t6mu5HEPhxcb1XOuxdpY82vCg2Q==",
+      "dependencies": {
+        "@octokit/types": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.2.4.tgz",
+      "integrity": "sha512-d9dTsqdePBqOn7aGkyRFe7pQpCXdibSJ5SFnrTr0axevObZrpz3qkWm7t/NjYv5a66z6vhfteriaq4FRz3e0Qg==",
+      "dependencies": {
+        "@octokit/auth-token": "^2.4.4",
+        "@octokit/graphql": "^4.5.8",
+        "@octokit/request": "^5.4.12",
+        "@octokit/types": "^6.0.3",
+        "before-after-hook": "^2.1.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.10.tgz",
+      "integrity": "sha512-9+Xef8nT7OKZglfkOMm7IL6VwxXUQyR7DUSU0LH/F7VNqs8vyd7es5pTfz9E7DwUIx7R3pGscxu1EBhYljyu7Q==",
+      "dependencies": {
+        "@octokit/types": "^6.0.0",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "4.5.8",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.5.8.tgz",
+      "integrity": "sha512-WnCtNXWOrupfPJgXe+vSmprZJUr0VIu14G58PMlkWGj3cH+KLZEfKMmbUQ6C3Wwx6fdhzVW1CD5RTnBdUHxhhA==",
+      "dependencies": {
+        "@octokit/request": "^5.3.0",
+        "@octokit/types": "^6.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-6.0.0.tgz",
+      "integrity": "sha512-CnDdK7ivHkBtJYzWzZm7gEkanA7gKH6a09Eguz7flHw//GacPJLmkHA3f3N++MJmlxD1Fl+mB7B32EEpSCwztQ=="
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.6.2.tgz",
+      "integrity": "sha512-3Dy7/YZAwdOaRpGQoNHPeT0VU1fYLpIUdPyvR37IyFLgd6XSij4j9V/xN/+eSjF2KKvmfIulEh9LF1tRPjIiDA==",
+      "dependencies": {
+        "@octokit/types": "^6.0.1"
+      }
+    },
+    "node_modules/@octokit/plugin-request-log": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.2.tgz",
+      "integrity": "sha512-oTJSNAmBqyDR41uSMunLQKMX0jmEXbwD1fpz8FG27lScV3RhtGfBa1/BBLym+PxcC16IBlF7KH9vP1BUYxA+Eg=="
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.0.0.tgz",
+      "integrity": "sha512-Jc7CLNUueIshXT+HWt6T+M0sySPjF32mSFQAK7UfAg8qGeRI6OM1GSBxDLwbXjkqy2NVdnqCedJcP1nC785JYg==",
+      "dependencies": {
+        "@octokit/types": "^6.13.0",
+        "deprecation": "^2.3.1"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=3"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "5.4.12",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.12.tgz",
+      "integrity": "sha512-MvWYdxengUWTGFpfpefBBpVmmEYfkwMoxonIB3sUGp5rhdgwjXL1ejo6JbgzG/QD9B/NYt/9cJX1pxXeSIUCkg==",
+      "dependencies": {
+        "@octokit/endpoint": "^6.0.1",
+        "@octokit/request-error": "^2.0.0",
+        "@octokit/types": "^6.0.3",
+        "deprecation": "^2.0.0",
+        "is-plain-object": "^5.0.0",
+        "node-fetch": "^2.6.1",
+        "once": "^1.4.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.4.tgz",
+      "integrity": "sha512-LjkSiTbsxIErBiRh5wSZvpZqT4t0/c9+4dOe0PII+6jXR+oj/h66s7E4a/MghV7iT8W9ffoQ5Skoxzs96+gBPA==",
+      "dependencies": {
+        "@octokit/types": "^6.0.0",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/@octokit/rest": {
+      "version": "18.5.2",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.5.2.tgz",
+      "integrity": "sha512-Kz03XYfKS0yYdi61BkL9/aJ0pP2A/WK5vF/syhu9/kY30J8He3P68hv9GRpn8bULFx2K0A9MEErn4v3QEdbZcw==",
+      "dependencies": {
+        "@octokit/core": "^3.2.3",
+        "@octokit/plugin-paginate-rest": "^2.6.2",
+        "@octokit/plugin-request-log": "^1.0.2",
+        "@octokit/plugin-rest-endpoint-methods": "5.0.0"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.13.0.tgz",
+      "integrity": "sha512-W2J9qlVIU11jMwKHUp5/rbVUeErqelCsO5vW5PKNb7wAXQVUz87Rc+imjlEvpvbH8yUb+KHmv8NEjVZdsdpyxA==",
+      "dependencies": {
+        "@octokit/openapi-types": "^6.0.0"
+      }
+    },
+    "node_modules/@types/color-convert": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/color-convert/-/color-convert-2.0.0.tgz",
+      "integrity": "sha512-m7GG7IKKGuJUXvkZ1qqG3ChccdIM/qBBo913z+Xft0nKCX4hAU/IxKwZBU4cpRZ7GS5kV4vOblUkILtSShCPXQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/color-name": "*"
+      }
+    },
+    "node_modules/@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "12.0.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.8.tgz",
+      "integrity": "sha512-b8bbUOTwzIY3V5vDTY1fIJ+ePKDUBqt2hC2woVGotdQQhG/2Sh62HOKHrT7ab+VerXAcPyAiTEipPu/FsreUtg==",
+      "dev": true
+    },
+    "node_modules/@types/source-map": {
+      "version": "0.1.29",
+      "resolved": "https://registry.npmjs.org/@types/source-map/-/source-map-0.1.29.tgz",
+      "integrity": "sha1-1wSKYBgLCfiqbVO9oxHGtRy9cBg="
+    },
+    "node_modules/@types/winreg": {
+      "version": "1.2.30",
+      "resolved": "https://registry.npmjs.org/@types/winreg/-/winreg-1.2.30.tgz",
+      "integrity": "sha1-kdZxDlNtNFucmwF8V0z2qNpkxRg=",
+      "dev": true
+    },
+    "node_modules/@types/yargs": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.0.tgz",
+      "integrity": "sha512-hY0o+kcz9M6kH32NUeb6VURghqMuCVkiUx+8Btsqhj4Hhov/hVGUx9DmBJeIkzlp1uAQK4wngQBCjqWdUUkFyA==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-13.0.0.tgz",
+      "integrity": "sha512-wBlsw+8n21e6eTd4yVv8YD/E3xq0O6nNnJIquutAsFGE7EyMKz7W6RNT6BRu1SmdgmlCZ9tb0X+j+D6HGr8pZw==",
+      "dev": true
+    },
+    "node_modules/ansi-regex": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/async-limiter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "node_modules/before-after-hook": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.1.0.tgz",
+      "integrity": "sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A=="
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chalk/node_modules/ansi-styles": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+      "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+      "dev": true,
+      "dependencies": {
+        "@types/color-name": "^1.1.1",
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chalk/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/chalk/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/cliui": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "dependencies": {
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.2.0",
+        "wrap-ansi": "^5.1.0"
+      }
+    },
+    "node_modules/collection-core": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/collection-core/-/collection-core-1.1.2.tgz",
+      "integrity": "sha512-gXezPbbHWVgsulZvi1lr7wv7MZNh5Ub+VjgSnC7aQQiVJMztdjXaBTuK1XwckF26+QsnbQJazxuzLgEHWlG6qg==",
+      "dependencies": {
+        "@esfx/collection-core": "^1.0.0-pre.2",
+        "@esfx/collection-core-shim": "^1.0.0-pre.2"
+      }
+    },
+    "node_modules/color": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
+      "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
+      "dependencies": {
+        "color-convert": "^1.9.1",
+        "color-string": "^1.5.2"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "node_modules/color-string": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
+      "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "node_modules/cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "dependencies": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      },
+      "engines": {
+        "node": ">=4.8"
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
+    },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.588169",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.588169.tgz",
+      "integrity": "sha512-DDGCT3YFiamX4jRPqg4galOrQS8DsU0j+xM5iaR0YB5TM1fjCZejQ7MSe9ByIMIq4IsnULY/4Qp3TBWAUjMgXw=="
+    },
+    "node_modules/emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/equatable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/equatable/-/equatable-1.2.0.tgz",
+      "integrity": "sha512-cBKXA5hWVMxZDDF+n2OEGgbdfmN75ElXbL1mgugw/vcvmWt2jxMjBfONtiocsVdfgakxE7T2Kz14533tZaw02g==",
+      "dependencies": {
+        "@esfx/collections": "^1.0.0-pre.2",
+        "@esfx/equatable": "^1.0.0-pre.2",
+        "@esfx/equatable-shim": "^1.0.0-pre.2"
+      }
+    },
+    "node_modules/execa": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+      "dependencies": {
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^4.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "node_modules/invert-kv": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+      "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+    },
+    "node_modules/iterable-query": {
+      "version": "1.0.0-pre.15",
+      "resolved": "https://registry.npmjs.org/iterable-query/-/iterable-query-1.0.0-pre.15.tgz",
+      "integrity": "sha512-nhemUfQIgEZZO7fcxatMk2g5GQtAv34UUjMFl375F/dTNuLPiFfbGRaoPGM5SftrnF0OfHSDICwPhu6RStxw0Q==",
+      "dependencies": {
+        "collection-core": "^1.0.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "node_modules/lcid": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+      "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+      "dependencies": {
+        "invert-kv": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/map-age-cleaner": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+      "dependencies": {
+        "p-defer": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/mem": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+      "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
+      "dependencies": {
+        "map-age-cleaner": "^0.1.1",
+        "mimic-fn": "^2.0.0",
+        "p-is-promise": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/noice-json-rpc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/noice-json-rpc/-/noice-json-rpc-1.2.0.tgz",
+      "integrity": "sha512-Wm+otW+drKzdqlSPoSwj34tUEq/Xj1gX6Cr2avrykvTW4IY7d3ngLmP+PErALzS0s9nYRokXvYDM54sbFvLlDA=="
+    },
+    "node_modules/npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "dependencies": {
+        "path-key": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/os-locale": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+      "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+      "dependencies": {
+        "execa": "^1.0.0",
+        "lcid": "^2.0.0",
+        "mem": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/p-defer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/p-is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
+      "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+      "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+    },
+    "node_modules/semver": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+    },
+    "node_modules/shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dependencies": {
+        "shebang-regex": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "dependencies": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+      "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+    },
+    "node_modules/typescript": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.2.tgz",
+      "integrity": "sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/universal-user-agent": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
+    },
+    "node_modules/vscode-chrome-debug-core": {
+      "version": "6.7.50",
+      "resolved": "https://registry.npmjs.org/vscode-chrome-debug-core/-/vscode-chrome-debug-core-6.7.50.tgz",
+      "integrity": "sha512-SKLRtXtU6Cymn9ii+3s/M6SSoYJ01ASnRSPgLCTt5lVGMl2A2hxcrrt6tq2tm9vtkP9jHLhrkaG6nucCFZIcww==",
+      "dependencies": {
+        "@types/source-map": "^0.1.27",
+        "color": "^3.0.0",
+        "devtools-protocol": "0.0.588169",
+        "glob": "^7.1.3",
+        "noice-json-rpc": "^1.2.0",
+        "source-map": "^0.6.1",
+        "vscode-debugadapter": "^1.34.0",
+        "vscode-debugprotocol": "^1.34.0",
+        "vscode-nls": "^4.0.0",
+        "vscode-uri": "^2.0.2",
+        "ws": "^6.0.0"
+      }
+    },
+    "node_modules/vscode-debugadapter": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/vscode-debugadapter/-/vscode-debugadapter-1.40.0.tgz",
+      "integrity": "sha512-cudm9ROtFRxiBgcM+B8cQXA1DfsRKaOfEYDMh9upxbYxN3v0c40SHCPmNivIYp7LDzcG60UGaIYD1vsUfC1Qcg==",
+      "dependencies": {
+        "mkdirp": "^0.5.1",
+        "vscode-debugprotocol": "1.40.0"
+      }
+    },
+    "node_modules/vscode-debugadapter/node_modules/vscode-debugprotocol": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/vscode-debugprotocol/-/vscode-debugprotocol-1.40.0.tgz",
+      "integrity": "sha512-Fwze+9qbLDPuQUhtITJSu/Vk6zIuakNM1iR2ZiZRgRaMEgBpMs2JSKaT0chrhJHCOy6/UbpsUbUBIseF6msV+g=="
+    },
+    "node_modules/vscode-debugprotocol": {
+      "version": "1.35.0",
+      "resolved": "https://registry.npmjs.org/vscode-debugprotocol/-/vscode-debugprotocol-1.35.0.tgz",
+      "integrity": "sha512-+OMm11R1bGYbpIJ5eQIkwoDGFF4GvBz3Ztl6/VM+/RNNb2Gjk2c0Ku+oMmfhlTmTlPCpgHBsH4JqVCbUYhu5bA=="
+    },
+    "node_modules/vscode-nls": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-4.1.1.tgz",
+      "integrity": "sha512-4R+2UoUUU/LdnMnFjePxfLqNhBS8lrAFyX7pjb2ud/lqDkrUavFUTcG7wR0HBZFakae0Q6KLBFjMS6W93F403A=="
+    },
+    "node_modules/vscode-uri": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-2.0.2.tgz",
+      "integrity": "sha512-VebpIxm9tG0fG2sBOhnsSPzDYuNUPP1UQW4K3mwthlca4e4f3d6HKq3HkITC2OPFomOaB7pHTSjcpdFWjfYTzg=="
+    },
+    "node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+    },
+    "node_modules/winreg": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/winreg/-/winreg-1.2.4.tgz",
+      "integrity": "sha1-ugZWKbepJRMOFXeRCM9UCZDpjRs="
+    },
+    "node_modules/wrap-ansi": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+      "dependencies": {
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "node_modules/ws": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+      "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+      "dependencies": {
+        "async-limiter": "~1.0.0"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
+    },
+    "node_modules/yargs": {
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.4.tgz",
+      "integrity": "sha512-HG/DWAJa1PAnHT9JAhNa8AbAv3FPaiLzioSjCcmuXXhP8MlpHO5vwls4g4j6n30Z74GVQj8Xa62dWVx1QCGklg==",
+      "dependencies": {
+        "cliui": "^5.0.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "os-locale": "^3.1.0",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^13.1.0"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
+    }
+  },
   "dependencies": {
     "@esfx/collection-core": {
       "version": "1.0.0-pre.8",
@@ -216,9 +1399,9 @@
       }
     },
     "@octokit/openapi-types": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-2.0.0.tgz",
-      "integrity": "sha512-J4bfM7lf8oZvEAdpS71oTvC1ofKxfEZgU5vKVwzZKi4QPiL82udjpseJwxPid9Pu2FNmyRQOX4iEj6W1iOSnPw=="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-6.0.0.tgz",
+      "integrity": "sha512-CnDdK7ivHkBtJYzWzZm7gEkanA7gKH6a09Eguz7flHw//GacPJLmkHA3f3N++MJmlxD1Fl+mB7B32EEpSCwztQ=="
     },
     "@octokit/plugin-paginate-rest": {
       "version": "2.6.2",
@@ -234,11 +1417,11 @@
       "integrity": "sha512-oTJSNAmBqyDR41uSMunLQKMX0jmEXbwD1fpz8FG27lScV3RhtGfBa1/BBLym+PxcC16IBlF7KH9vP1BUYxA+Eg=="
     },
     "@octokit/plugin-rest-endpoint-methods": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-4.4.1.tgz",
-      "integrity": "sha512-+v5PcvrUcDeFXf8hv1gnNvNLdm4C0+2EiuWt9EatjjUmfriM1pTMM+r4j1lLHxeBQ9bVDmbywb11e3KjuavieA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.0.0.tgz",
+      "integrity": "sha512-Jc7CLNUueIshXT+HWt6T+M0sySPjF32mSFQAK7UfAg8qGeRI6OM1GSBxDLwbXjkqy2NVdnqCedJcP1nC785JYg==",
       "requires": {
-        "@octokit/types": "^6.1.0",
+        "@octokit/types": "^6.13.0",
         "deprecation": "^2.3.1"
       }
     },
@@ -268,23 +1451,22 @@
       }
     },
     "@octokit/rest": {
-      "version": "18.0.12",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.0.12.tgz",
-      "integrity": "sha512-hNRCZfKPpeaIjOVuNJzkEL6zacfZlBPV8vw8ReNeyUkVvbuCvvrrx8K8Gw2eyHHsmd4dPlAxIXIZ9oHhJfkJpw==",
+      "version": "18.5.2",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.5.2.tgz",
+      "integrity": "sha512-Kz03XYfKS0yYdi61BkL9/aJ0pP2A/WK5vF/syhu9/kY30J8He3P68hv9GRpn8bULFx2K0A9MEErn4v3QEdbZcw==",
       "requires": {
         "@octokit/core": "^3.2.3",
         "@octokit/plugin-paginate-rest": "^2.6.2",
         "@octokit/plugin-request-log": "^1.0.2",
-        "@octokit/plugin-rest-endpoint-methods": "4.4.1"
+        "@octokit/plugin-rest-endpoint-methods": "5.0.0"
       }
     },
     "@octokit/types": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.1.1.tgz",
-      "integrity": "sha512-btm3D6S7VkRrgyYF31etUtVY/eQ1KzrNRqhFt25KSe2mKlXuLXJilglRC6eDA2P6ou94BUnk/Kz5MPEolXgoiw==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.13.0.tgz",
+      "integrity": "sha512-W2J9qlVIU11jMwKHUp5/rbVUeErqelCsO5vW5PKNb7wAXQVUz87Rc+imjlEvpvbH8yUb+KHmv8NEjVZdsdpyxA==",
       "requires": {
-        "@octokit/openapi-types": "^2.0.0",
-        "@types/node": ">= 8"
+        "@octokit/openapi-types": "^6.0.0"
       }
     },
     "@types/color-convert": {
@@ -305,12 +1487,7 @@
     "@types/node": {
       "version": "12.0.8",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.8.tgz",
-      "integrity": "sha512-b8bbUOTwzIY3V5vDTY1fIJ+ePKDUBqt2hC2woVGotdQQhG/2Sh62HOKHrT7ab+VerXAcPyAiTEipPu/FsreUtg=="
-    },
-    "@types/prompts": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/prompts/-/prompts-2.0.0.tgz",
-      "integrity": "sha512-Rl7itDnYA+Eunkd8WUcB7SF8B0cuzykwDWeQ2rfZry8fqdXJ3piw5B+SgzHWBYQuHCwF7E5iyozQf3BziCuXhA==",
+      "integrity": "sha512-b8bbUOTwzIY3V5vDTY1fIJ+ePKDUBqt2hC2woVGotdQQhG/2Sh62HOKHrT7ab+VerXAcPyAiTEipPu/FsreUtg==",
       "dev": true
     },
     "@types/source-map": {
@@ -635,11 +1812,6 @@
         "tslib": "^1.9.3"
       }
     },
-    "kleur": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="
-    },
     "lcid": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
@@ -793,15 +1965,6 @@
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
-    "prompts": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.1.0.tgz",
-      "integrity": "sha512-+x5TozgqYdOwWsQFZizE/Tra3fKvAoy037kOyU6cgz84n8f6zxngLOV4O32kTwt9FcLCxAqw0P/c8rOr9y+Gfg==",
-      "requires": {
-        "kleur": "^3.0.2",
-        "sisteransi": "^1.0.0"
-      }
-    },
     "pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -856,11 +2019,6 @@
       "requires": {
         "is-arrayish": "^0.3.1"
       }
-    },
-    "sisteransi": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.0.tgz",
-      "integrity": "sha512-N+z4pHB4AmUv0SjveWRd6q1Nj5w62m5jodv+GD8lvmbY/83T/rpbJGZOnK5T149OldDj4Db07BSv9xY4K6NTPQ=="
     },
     "source-map": {
       "version": "0.6.1",
@@ -1006,9 +2164,9 @@
       }
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
     },
     "yargs": {
       "version": "13.2.4",
@@ -1029,9 +2187,9 @@
       }
     },
     "yargs-parser": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-      "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -21,17 +21,15 @@
   "devDependencies": {
     "@types/color-convert": "^2.0.0",
     "@types/node": "^12.0.8",
-    "@types/prompts": "^2.0.0",
     "@types/winreg": "^1.2.30",
     "@types/yargs": "^13.0.0",
     "chalk": "^3.0.0",
     "typescript": "^4.1.2"
   },
   "dependencies": {
-    "@octokit/rest": "^18.0.12",
+    "@octokit/rest": "^18.5.2",
     "equatable": "^1.2.0",
     "iterable-query": "^1.0.0-pre.15",
-    "prompts": "^2.1.0",
     "vscode-chrome-debug-core": "^6.7.50",
     "winreg": "^1.2.4",
     "yargs": "^13.2.4"

--- a/src/context.ts
+++ b/src/context.ts
@@ -8,6 +8,7 @@ export interface ColumnRunDownState {
     cards: Card[];
     offset: number;
     oldestFirst: boolean;
+    completedCount: number;
 }
 
 export interface WorkArea {

--- a/src/credentialManager.ts
+++ b/src/credentialManager.ts
@@ -1,0 +1,113 @@
+import { spawnSync } from "child_process";
+
+export interface GitCredentialRequest {
+    protocol: string;
+    host: string;
+    path?: string;
+    username?: string;
+    password?: string;
+}
+
+export interface GitCredential {
+    protocol: string;
+    host: string;
+    path?: string;
+    username: string;
+    password: string;
+}
+
+export interface GitUrlCredentialRequest {
+    url: string;
+    username?: string;
+    password?: string;
+}
+
+export interface GitUrlCredential {
+    url: string;
+    username: string;
+    password: string;
+}
+
+export function stringifyGitCredential(credential: GitCredentialRequest | GitUrlCredentialRequest | GitCredential | GitUrlCredential) {
+    let s = "";
+    for (const [key, value] of Object.entries(credential)) {
+        if (value !== undefined) {
+            if (/[\0\r\n=]/.test(key)) throw new TypeError(`'key' cannot contain NUL, newline, or '=' characters`);
+            if (/[\0\r\n]/.test(value)) throw new TypeError(`'value' cannot contain NUL or newline characters`);
+            s += `${key}=${value}\n`;
+        }
+    }
+    s += "\n";
+    return s;
+}
+
+export function parseGitCredentialRequest(text: string) {
+    const credential: Partial<GitCredentialRequest & GitUrlCredentialRequest> = { };
+    for (const [key, value] of Array.from(text.matchAll(/^([^=]+)=(.*)$/gm), m => [m[1], m[2]])) {
+        if (key in credential) throw new TypeError("Duplicate key");
+        switch (key) {
+            case "url":
+            case "protocol":
+            case "host":
+            case "path":
+            case "username":
+            case "password":
+                break;
+            default:
+                throw new TypeError(`Invalid key '${key}'.`);
+        }
+        credential[key] = value;
+    }
+    if (credential.url !== undefined) {
+        if (credential.protocol !== undefined) throw new TypeError("'url' cannot be combined with 'protocol'");
+        if (credential.host !== undefined) throw new TypeError("'url' cannot be combined with 'host'");
+        if (credential.path !== undefined) throw new TypeError("'url' cannot be combined with 'path'");
+        return credential as GitUrlCredentialRequest;
+    }
+    if (credential.protocol === undefined) throw new TypeError("GitCredential missing 'url' or 'protocol'");
+    if (credential.host === undefined) throw new TypeError("GitCredential missing 'host'");
+    return credential as GitCredentialRequest;
+}
+
+export function parseGitCredential(text: string): GitCredential | GitUrlCredential {
+    const credential = parseGitCredentialRequest(text);
+    if (credential.username === undefined) throw new TypeError("GitCredential missing 'username'")
+    if (credential.password === undefined) throw new TypeError("GitCredential missing 'password'")
+    return credential as GitCredential | GitUrlCredential;
+}
+
+export function fillGitCredential(credential: GitCredentialRequest | GitUrlCredentialRequest) {
+    const { stdout, status } = spawnSync("git", ["credential", "fill"], {
+        encoding: "utf8",
+        stdio: ["pipe", "pipe", "inherit"],
+        input: stringifyGitCredential(credential),
+        shell: true,
+        windowsVerbatimArguments: true,
+        windowsHide: true
+    });
+    return status ? undefined : parseGitCredential(stdout);
+}
+
+export function approveGitCredential(credential: GitCredential | GitUrlCredential) {
+    const { status } = spawnSync("git", ["credential", "approve"], {
+        encoding: "utf8",
+        stdio: ["pipe", "inherit", "inherit"],
+        input: stringifyGitCredential(credential),
+        shell: true,
+        windowsVerbatimArguments: true,
+        windowsHide: true
+    });
+    return !status;
+}
+
+export function rejectGitCredential(credential: GitCredential | GitUrlCredential) {
+    const { status } = spawnSync("git", ["credential", "reject"], {
+        encoding: "utf8",
+        stdio: ["pipe", "inherit", "inherit"],
+        input: stringifyGitCredential(credential),
+        shell: true,
+        windowsVerbatimArguments: true,
+        windowsHide: true
+    });
+    return !status;
+}

--- a/src/external/@octokit/rest.d.ts
+++ b/src/external/@octokit/rest.d.ts
@@ -1,27 +1,37 @@
-import { Octokit, RestEndpointMethodTypes, RestEndpointMethodTypes } from "@octokit/rest";
+import { Octokit as Core } from "@octokit/core";
+import { RestEndpointMethodTypes } from "@octokit/plugin-rest-endpoint-methods";
+export {};
 
-// Workaround for @octokit/rest removing named types for REST API responses
+type OctokitOptions = NonNullable<ConstructorParameters<typeof Core>[0]>;
+
+// Workaround for @octokit/core removing named types for REST API responses
 declare module "@octokit/rest" {
-    namespace Octokit {
-        type Options = NonNullable<ConstructorParameters<typeof Octokit>[0]>;
-        type UsersGetAuthenticatedResponse = RestEndpointMethodTypes["users"]["getAuthenticated"]["response"]["data"];
-        type ProjectsListForRepoResponse = RestEndpointMethodTypes["projects"]["listForRepo"]["response"]["data"];
-        type ProjectsListForRepoResponseItem = ProjectsListForRepoResponse[number];
-        type ProjectsListColumnsResponse = RestEndpointMethodTypes["projects"]["listColumns"]["response"]["data"];
-        type ProjectsListColumnsResponseItem = ProjectsListColumnsResponse[number];
-        type ProjectsListCardsResponse = RestEndpointMethodTypes["projects"]["listCards"]["response"]["data"];
-        type ProjectsListCardsResponseItem = ProjectsListCardsResponse[number];
-        type PullsGetResponse = RestEndpointMethodTypes["pulls"]["get"]["response"]["data"];
-        type PullsListReviewsResponse = RestEndpointMethodTypes["pulls"]["listReviews"]["response"]["data"];
-        type PullsListReviewsResponseItem = PullsListReviewsResponse[number];
-        type TeamsListMembersResponse = RestEndpointMethodTypes["teams"]["listMembersInOrg"]["response"]["data"];
-        type TeamsListMembersResponseItem = TeamsListMembersResponse[number];
-        type PullsGetResponseLabelItem = PullsGetResponse["labels"][number];
-        type PullsListCommitsResponse = RestEndpointMethodTypes["pulls"]["listCommits"]["response"]["data"];
-        type PullsListCommitsResponseItem = PullsListCommitsResponse[number];
-        type ReposListCommitsResponse = RestEndpointMethodTypes["repos"]["listCommits"]["response"]["data"];
-        type ReposListCommitsResponseItem = ReposListCommitsResponse[number];
-        type IssuesListCommentsResponse = RestEndpointMethodTypes["issues"]["listComments"]["response"]["data"];
-        type IssuesListCommentsResponseItem = IssuesListCommentsResponse[number];
+    interface DefaultTokenAuthOptions extends OctokitOptions {
+        auth?: string;
+        authStrategy?: undefined;
     }
+    interface AuthStrategyOptions<TAuth extends object = object> extends OctokitOptions {
+        auth?: TAuth
+        authStrategy?: (strategyOptions: { request: Core["request"], log: Core["log"], octokit: Core, octokitOptions: Omit<Options, "authStrategy"> } & TAuth) => () => Promise<{}>;
+    }
+    type Options = DefaultTokenAuthOptions | AuthStrategyOptions;
+    type UsersGetAuthenticatedResponse = RestEndpointMethodTypes["users"]["getAuthenticated"]["response"]["data"];
+    type ProjectsListForRepoResponse = RestEndpointMethodTypes["projects"]["listForRepo"]["response"]["data"];
+    type ProjectsListForRepoResponseItem = ProjectsListForRepoResponse[number];
+    type ProjectsListColumnsResponse = RestEndpointMethodTypes["projects"]["listColumns"]["response"]["data"];
+    type ProjectsListColumnsResponseItem = ProjectsListColumnsResponse[number];
+    type ProjectsListCardsResponse = RestEndpointMethodTypes["projects"]["listCards"]["response"]["data"];
+    type ProjectsListCardsResponseItem = ProjectsListCardsResponse[number];
+    type PullsGetResponse = RestEndpointMethodTypes["pulls"]["get"]["response"]["data"];
+    type PullsListReviewsResponse = RestEndpointMethodTypes["pulls"]["listReviews"]["response"]["data"];
+    type PullsListReviewsResponseItem = PullsListReviewsResponse[number];
+    type TeamsListMembersResponse = RestEndpointMethodTypes["teams"]["listMembersInOrg"]["response"]["data"];
+    type TeamsListMembersResponseItem = TeamsListMembersResponse[number];
+    type PullsGetResponseLabelItem = PullsGetResponse["labels"][number];
+    type PullsListCommitsResponse = RestEndpointMethodTypes["pulls"]["listCommits"]["response"]["data"];
+    type PullsListCommitsResponseItem = PullsListCommitsResponse[number];
+    type ReposListCommitsResponse = RestEndpointMethodTypes["repos"]["listCommits"]["response"]["data"];
+    type ReposListCommitsResponseItem = ReposListCommitsResponse[number];
+    type IssuesListCommentsResponse = RestEndpointMethodTypes["issues"]["listComments"]["response"]["data"];
+    type IssuesListCommentsResponseItem = IssuesListCommentsResponse[number];
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,12 +16,11 @@
 
 import * as fs from "fs";
 import chalk from "chalk";
-import prompts = require("prompts");
 import colorConvert = require("color-convert");
 import { ProjectService, Column, Label } from "./github";
 import { Chrome } from "./chrome";
 import { pushPrompt, addOnQuit, isPromptVisible, hidePrompt, showPrompt, getPromptLineCount, addOnPromptSizeChange } from "./prompt";
-import { readSkipped, saveSkipped } from "./settings";
+import { readSkipped } from "./settings";
 import { Screen } from "./screen";
 import { createMergePrompt } from "./prompts/merge";
 import { createApprovalPrompt } from "./prompts/approval";
@@ -29,17 +28,15 @@ import { ColumnRunDownState, Context, WorkArea } from "./context";
 import { createFilterPrompt } from "./prompts/filter";
 import { createRunDownPrompt } from "./prompts/runDown";
 import { init } from "./init";
-import { Octokit } from "@octokit/rest";
 
 async function main() {
     let {
         token,
-        username,
-        password,
+        credential,
         settings
     } = await init();
 
-    if (!token && (!username || !password)) {
+    if (!token) {
         return;
     }
 
@@ -52,20 +49,8 @@ async function main() {
     });
 
     const service = new ProjectService({
-        github: {
-            auth: token || {
-                username: username!,
-                password: password!,
-                async on2fa() {
-                    const { otp } = await prompts({
-                        type: "text",
-                        name: "otp",
-                        message: "GitHub 2FA code"
-                    }, { onCancel() { process.exit(1); } });
-                    return otp;
-                }
-            }
-        },
+        credential,
+        github: { auth: token },
         project: ProjectService.defaultProject,
         columns: ProjectService.defaultColumns,
         owner: "DefinitelyTyped",
@@ -73,6 +58,7 @@ async function main() {
         team: "typescript-team"
     });
 
+    credential = undefined;
     const columns = await service.getColumns();
     const screen = new Screen(process.stdout, {
         getPromptLineCount,
@@ -102,6 +88,8 @@ async function main() {
     let lastColumn: Column | undefined;
     let lastShowAction = false;
     let lastShowReview = false;
+    let lastColumn1CompletedCount: number | undefined;
+    let lastColumn2CompletedCount: number | undefined;
 
     while (true) {
         context.currentPull = undefined;
@@ -113,23 +101,29 @@ async function main() {
             context.reviewState = await populateState(columns["Needs Maintainer Review"]);
         }
 
-        context.workArea = nextCard(context.reviewState) || nextCard(context.actionState);
+        const column1 = context.reviewState;
+        const column2 = context.actionState;
+        context.workArea = nextCard(column1) || nextCard(column2);
         if (lastShowAction !== settings.needsAction ||
             lastShowReview !== settings.needsReview ||
             !context.workArea ||
-            context.workArea.column.column !== lastColumn) {
+            context.workArea.column.column !== lastColumn ||
+            lastColumn1CompletedCount !== column1?.completedCount ||
+            lastColumn2CompletedCount !== column2?.completedCount) {
             lastShowAction = settings.needsAction;
             lastShowReview = settings.needsReview;
+            lastColumn1CompletedCount = column1?.completedCount;
+            lastColumn2CompletedCount = column2?.completedCount;
             screen.clearHeader();
             const columnName = context.workArea?.column.column.name;
             const column1Name = "Needs Maintainer Review";
             const column1Selected = columnName === column1Name ? "* " : "";
             const column1Color = column1Selected ? "bgCyan.whiteBright" : "bgGray.black";
-            const column1Count = context.reviewState?.cards.length ?? "excluded";
+            const column1Count = column1 ? column1Selected || lastColumn1CompletedCount ? `${lastColumn1CompletedCount || 0}/${column1.cards.length}` : column1.cards.length : "excluded";
             const column2Name = "Needs Maintainer Action";
             const column2Selected = columnName === column2Name ? "* " : "";
             const column2Color = column2Selected ? "bgCyan.whiteBright" : "bgGray.black";
-            const column2Count = context.actionState?.cards.length ?? "excluded";
+            const column2Count = column2 ? column2Selected || lastColumn2CompletedCount ? `${lastColumn2CompletedCount || 0}/${column2.cards.length}` : column2.cards.length : "excluded";
             const column1Left = column1Selected ? chalk.bgBlack.cyan("▟") : chalk.bgBlack.gray("▟");
             const column1Right = column1Selected ? chalk.bgBlack.cyan("▙") : chalk.bgBlack.gray("▙");
             const column2Left = column2Selected ? chalk.bgBlack.cyan("▟") : chalk.bgBlack.gray("▟");
@@ -240,7 +234,7 @@ async function main() {
 
     async function populateState(column: Column): Promise<ColumnRunDownState> {
         const cards = await service.getCards(column, settings.oldest);
-        return { column: column, cards, offset: 0, oldestFirst: settings.oldest };
+        return { column: column, cards, offset: 0, oldestFirst: settings.oldest, completedCount: 0 };
     }
 
     function nextCard(column: ColumnRunDownState | undefined): WorkArea | undefined {

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,15 +1,12 @@
-import prompts = require("prompts");
 import { argv } from "./options";
-import { spawn } from "child_process";
 import { getDefaultSettings, getDefaultSettingsFile, saveSettings, Settings } from "./settings";
 import { getChromePath } from "./chrome";
+import { fillGitCredential, GitCredential, GitUrlCredential } from "./credentialManager";
 
 export async function init() {
     const defaults = getDefaultSettings();
     let {
         token,
-        username,
-        password,
         save,
         "save-to": saveTo,
         needsReview = defaults.needsReview,
@@ -22,8 +19,8 @@ export async function init() {
         merge = defaults.merge,
         port = defaults.port,
         timeout = defaults.timeout,
+        username = defaults.username,
         chromePath,
-        useCredentialManager
     } = argv;
 
     if (port <= 0) port = "random";
@@ -34,81 +31,21 @@ export async function init() {
     }
 
     if (!token) {
-        token = process.env.GITHUB_API_TOKEN ?? process.env.FOCUS_DT_GITHUB_API_TOKEN ?? process.env.AUTH_TOKEN
+        token = process.env.GITHUB_API_TOKEN ?? process.env.FOCUS_DT_GITHUB_API_TOKEN ?? process.env.AUTH_TOKEN;
     }
 
-    if (!token && (!username || !password)) {
-        if (useCredentialManager) {
-            const entries = new Map<string, string>();
-            await new Promise<void>((resolve) => {
-                // 'git credential fill' takes arguments via stdin using `<key>=<value>\n`, and outputs results in the same format.
-                // see https://git-scm.com/docs/git-credential#IOFMT
-                const proc = spawn("git", ["credential", "fill"], { stdio: "pipe" });
-                proc.stdout
-                    .setEncoding("utf8")
-                    .on("data", (data: string) => {
-                        const lines = data.split(/\r?\n/g);
-                        for (const line of lines) {
-                            const match = /^([^=]+)=(.*)$/.exec(line);
-                            if (!match) continue;
-                            entries.set(match[1], match[2]);
-                        }
-                    });
-                proc.stderr
-                    .setEncoding("utf8")
-                    .on("data", (data: string) => {
-                        console.log(data);
-                    });
-                proc
-                    .on("error", () => resolve())
-                    .on("close", () => resolve());
-                // write inputs
-                proc.stdin.write("protocol=https\n");
-                proc.stdin.write("host=github.com\n");
-                proc.stdin.write("path=DefinitelyTyped/DefinitelyTyped.git\n");
-                if (username) proc.stdin.write(`username=${username}\n`);
-                if (password) proc.stdin.write(`password=${password}\n`);
-                proc.stdin.write("\n");
-            });
-            username = entries.get("username");
-            password = entries.get("password");
-            if (username === "PersonalAccessToken") {
-                token = password;
-                username = undefined;
-                password = undefined;
-            }
-            if (!token && (!username || !password)) {
-                process.exit(-1);
-            }
+    let credential: GitCredential | GitUrlCredential | undefined;
+    if (!token) {
+        credential = fillGitCredential({
+            protocol: "https",
+            host: "github.com",
+            path: "DefinitelyTyped/DefinitelyTyped.git",
+            username
+        });
+        if (!credential) {
+            process.exit(-1);
         }
-        else {
-            ({ token, username, password } = await prompts([
-                {
-                    type: "select",
-                    name: "choice",
-                    message: "GitHub Authentication",
-                    choices: [
-                        { title: "token", value: "token" },
-                        { title: "username", value: "username" },
-                    ],
-                },
-                {
-                    type: (_, answers) => answers.choice === "token" ? "text" : null,
-                    name: "token",
-                    message: "token"
-                },
-                {
-                    type: (_, answers) => answers.choice === "username" ? "text" : null,
-                    name: "username",
-                    message: "username"
-                },
-                {
-                    type: (_, answers) => answers.choice === "username" ? "text" : null,
-                    name: "password",
-                    message: "password"
-                },
-            ], { onCancel() { process.exit(1); } }));
-        }
+        token = credential.password;
     }
 
     const defaultMerge: "merge" | "squash" | "rebase" | undefined =
@@ -131,7 +68,8 @@ export async function init() {
         timeout,
         merge: defaultMerge,
         approve: approvalMode,
-        chromePath: chromePath ?? await getChromePath()
+        chromePath: chromePath ?? await getChromePath(),
+        username
     };
 
     if (save || saveTo) {
@@ -142,8 +80,7 @@ export async function init() {
 
     return {
         token,
-        username,
-        password,
+        credential,
         settings
     };
 }

--- a/src/options.ts
+++ b/src/options.ts
@@ -20,32 +20,15 @@ import { getDefaultSettingsFile, readSettings } from "./settings";
 export const options = yargs
     .usage("$0 [options]")
     // authentication
-    .option("token", {
-        desc: "GitHub Auth Token. Uses %GITHUB_API_TOKEN%, %FOCUS_DT_GITHUB_API_TOKEN%, or %AUTH_TOKEN% (in that order) if available",
-        group: "Authentication options:",
-        conflicts: ["username", "password"],
-        type: "string",
-    })
     .option("username", {
         desc: "GitHub Username",
         group: "Authentication options:",
-        conflicts: ["token"],
-        implies: "password",
         type: "string",
     })
-    .option("password", {
-        desc: "GitHub Password",
+    .option("token", {
+        desc: "GitHub Auth Token. Uses %GITHUB_API_TOKEN%, %FOCUS_DT_GITHUB_API_TOKEN%, or %AUTH_TOKEN% (in that order) if available",
         group: "Authentication options:",
-        conflicts: ["token"],
-        implies: "username",
         type: "string",
-    })
-    .option("useCredentialManager", {
-        desc: "Use 'git credential' to load/save the credential to use",
-        group: "Authentication options:",
-        conflicts: ["token", "password"],
-        type: "boolean",
-        alias: "C",
     })
     // configuration
     .option("config", {

--- a/src/prompts/runDown.ts
+++ b/src/prompts/runDown.ts
@@ -64,6 +64,7 @@ export function createRunDownPrompt(settings: Settings, appContext: Context, fil
                         if (appContext.skipped.delete(pull.number)) {
                             saveSkipped(appContext.skipped);
                         }
+                        if (appContext.workArea) appContext.workArea.column.completedCount++;
                         await prompt.close();
                     }
                     else {
@@ -118,6 +119,7 @@ export function createRunDownPrompt(settings: Settings, appContext: Context, fil
                         saveSkipped(appContext.skipped);
                     }
 
+                    if (appContext.workArea) appContext.workArea.column.completedCount++;
                     await prompt.close();
                 }
             },

--- a/src/screen.ts
+++ b/src/screen.ts
@@ -1,5 +1,5 @@
 import * as readline from "readline";
-import chalk, { Chalk } from "chalk";
+import chalk from "chalk";
 import { wordWrap } from "./wordWrap";
 
 const ESC = "\x1B";

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -26,6 +26,7 @@ export interface Settings {
     merge: MergeMode | undefined;
     approve: ApprovalMode;
     chromePath: string | undefined;
+    username: string | undefined;
 }
 
 export function getDefaultSettingsFile() {
@@ -78,7 +79,8 @@ export function getDefaultSettings(): Settings {
         merge: undefined,
         port: 9222,
         timeout: 10000,
-        chromePath: undefined
+        chromePath: undefined,
+        username: undefined
     };
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     /* Basic Options */
-    "target": "es2018",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
+    "target": "es2020",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     "incremental": true,                      /* Enable incremental compilation */
     // "lib": [],                             /* Specify library files to be included in the compilation. */


### PR DESCRIPTION
This removes the `--useCredentialManager` option in favor of always using `git credential fill` for authentication. This is due to the GitHub API dropping support for basic authentication. This also fixes the API calls to use `git credential approve` or `git credential reject` based on whether the authenticated token can actually perform the actions requested by `focus-dt`.

I also had to add further workarounds to get named types for various `@octokit/rest` API return values due to how they are defined and recent changes to the types that ship with the package.