### PR TITLE
Fix missing new on Intl.PluralRules

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -136,7 +136,7 @@ async function main() {
         if (!context.workArea) {
             lastColumn = undefined;
             screen.clearProgress();
-            const pluralRules = Intl.PluralRules("en-US", { type: "cardinal" });
+            const pluralRules = new Intl.PluralRules("en-US", { type: "cardinal" });
             const rule = pluralRules.select(context.skipped.size);
             screen.addProgress(context.skipped.size ? `No items remaining, but there ${rule === "one" ? "is" : "are"} ${context.skipped.size} skipped ${rule === "one" ? "item" : "items"} left to review.` : "No items remaining.");
             screen.render();


### PR DESCRIPTION
Even though this type checks, it throws once the queue empties:

```
TypeError: Constructor Intl.PluralRules requires 'new'
    at Intl.PluralRules (<anonymous>)
    at null.main (E:\work\focus-dt\src\index.ts:139:38)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```